### PR TITLE
New Gui version with two tabs (if qt > 5.9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(catkin REQUIRED COMPONENTS
     ros_end_effector #for action type 
     rosee_msg
     actionlib
+    urdf
     srdfdom
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,18 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
+## qt5.12 path to be declared
+#set(QT5_PATH "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64")
+set(QT5_PATH "" CACHE PATH "Path to QT > 5.9")
+set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT5_PATH}")
+
+
 if(CMAKE_VERSION VERSION_LESS "3.7.0")
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
-
-
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
@@ -25,8 +29,6 @@ find_package(catkin REQUIRED COMPONENTS
     srdfdom
 )
 
-## qt5.12 path to be declared
-set(QT5_PATH "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64")
 
 #not catkin packages
 find_package(Qt5 COMPONENTS Widgets REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 ## qt5.12 path to be declared
-#set(QT5_PATH "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64")
-#set(QT5_PATH "" CACHE PATH "Path to QT > 5.9")
-#set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT5_PATH}")
+set(QT5_PATH "/usr/share/qt5-15/5.15.0/gcc_64")
+set(QT5_PATH "" CACHE PATH "Path to QT > 5.9")
+set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT5_PATH}")
 
 
 if(CMAKE_VERSION VERSION_LESS "3.7.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
     ros_end_effector #for action type 
     rosee_msg
     actionlib
+    srdfdom
 )
 
 ## qt5.12 path to be declared
@@ -195,6 +196,11 @@ add_library(${PROJECT_NAME}_ContainerActionGroupBox SHARED
     include/rosee_gui/ContainerActionGroupBox.h 
 )
 
+add_library(${PROJECT_NAME}_RobotDescriptionHandler SHARED
+    src/RobotDescriptionHandler.cpp
+    include/rosee_gui/RobotDescriptionHandler.h 
+)
+
 
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
@@ -231,6 +237,7 @@ target_link_libraries(${PROJECT_NAME}_MainWindow
     ${catkin_LIBRARIES}
     Qt5::Widgets
     ${PROJECT_NAME}_TabAction
+    ${PROJECT_NAME}_RobotDescriptionHandler
 
 )
 
@@ -239,6 +246,7 @@ target_link_libraries(${PROJECT_NAME}_TabAction
     Qt5::Widgets
     ${PROJECT_NAME}_ContainerActionGroupBox
     ${PROJECT_NAME}_JointStateContainer
+    ${PROJECT_NAME}_RobotDescriptionHandler
 )
 
 
@@ -277,6 +285,7 @@ target_link_libraries(${PROJECT_NAME}_JointStateContainer
     ${catkin_LIBRARIES}
     Qt5::Widgets
     ${PROJECT_NAME}_JointStateTable
+    ${PROJECT_NAME}_RobotDescriptionHandler
 )
 target_link_libraries(${PROJECT_NAME}_ContainerActionGroupBox
     ${catkin_LIBRARIES}
@@ -284,6 +293,9 @@ target_link_libraries(${PROJECT_NAME}_ContainerActionGroupBox
     ${PROJECT_NAME}_SingleActionGroupBox
     ${PROJECT_NAME}_SingleActionBoxesGroupBox
     ${PROJECT_NAME}_SingleActionTimedGroupBox
+)
+target_link_libraries(${PROJECT_NAME}_RobotDescriptionHandler
+    ${catkin_LIBRARIES}
 )
 
 #############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,11 @@ add_library(${PROJECT_NAME}_TimerHandler SHARED
     include/rosee_gui/TimerHandler.h
 )
 
+add_library(${PROJECT_NAME}_JointStateTable SHARED
+    src/JointStateTable.cpp
+    include/rosee_gui/JointStateTable.h
+)
+
 
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
@@ -200,6 +205,7 @@ target_link_libraries(${PROJECT_NAME}_Window
     ${PROJECT_NAME}_ActionLayout
     ${PROJECT_NAME}_ActionBoxesLayout
     ${PROJECT_NAME}_ActionTimedLayout
+    ${PROJECT_NAME}_JointStateTable
 )
 
 
@@ -225,6 +231,11 @@ target_link_libraries(${PROJECT_NAME}_ActionTimedElement
 )
 
 target_link_libraries(${PROJECT_NAME}_TimerHandler
+    ${catkin_LIBRARIES}
+    Qt5::Widgets
+)
+
+target_link_libraries(${PROJECT_NAME}_JointStateTable
     ${catkin_LIBRARIES}
     Qt5::Widgets
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,9 @@ add_library(${PROJECT_NAME}_MainWindow SHARED
     include/rosee_gui/MainWindow.h
 )
 
-add_library(${PROJECT_NAME}_Window SHARED
-    src/Window.cpp
-    include/rosee_gui/Window.h
+add_library(${PROJECT_NAME}_TabAction SHARED
+    src/TabAction.cpp
+    include/rosee_gui/TabAction.h
 )
 
 add_library(${PROJECT_NAME}_SingleActionGroupBox SHARED
@@ -218,11 +218,11 @@ target_link_libraries(${PROJECT_NAME}_gui_main
 target_link_libraries(${PROJECT_NAME}_MainWindow
     ${catkin_LIBRARIES}
     Qt5::Widgets
-    ${PROJECT_NAME}_Window
+    ${PROJECT_NAME}_TabAction
 
 )
 
-target_link_libraries(${PROJECT_NAME}_Window
+target_link_libraries(${PROJECT_NAME}_TabAction
     ${catkin_LIBRARIES}
     Qt5::Widgets
     ${PROJECT_NAME}_ContainerActionGroupBox

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,11 @@ include_directories(
 
 ## Declare a C++ library
 # needed also the .h for qt automoc things
+add_library(${PROJECT_NAME}_MainWindow SHARED
+    src/MainWindow.cpp
+    include/rosee_gui/MainWindow.h
+)
+
 add_library(${PROJECT_NAME}_Window SHARED
     src/Window.cpp
     include/rosee_gui/Window.h
@@ -206,12 +211,19 @@ set_target_properties(${PROJECT_NAME}_gui_main PROPERTIES OUTPUT_NAME "gui_main"
 target_link_libraries(${PROJECT_NAME}_gui_main
     ${catkin_LIBRARIES}
     Qt5::Widgets
-    ${PROJECT_NAME}_Window
+    ${PROJECT_NAME}_MainWindow
     ${PROJECT_NAME}_TimerHandler
+)
+
+target_link_libraries(${PROJECT_NAME}_MainWindow
+    ${catkin_LIBRARIES}
+    Qt5::Widgets
+
 )
 
 target_link_libraries(${PROJECT_NAME}_Window
     ${catkin_LIBRARIES}
+    Qt5::Widgets
     ${PROJECT_NAME}_ContainerActionGroupBox
     ${PROJECT_NAME}_JointStateContainer
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,11 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-## qt5.12 path to be declared
-set(QT5_PATH "/usr/share/qt5-15/5.15.0/gcc_64")
+#set(QT5_PATH "/usr/share/qt5-15/5.15.0/gcc_64") #iit pc
+#set(QT5_PATH "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64") #tori pc
+
 set(QT5_PATH "" CACHE PATH "Path to QT > 5.9")
 set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT5_PATH}")
-
 
 if(CMAKE_VERSION VERSION_LESS "3.7.0")
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -31,9 +31,10 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 
-#not catkin packages
+#First one is necessary because even if we have a qt version greater than 5.9,
+#if we use only the second find package the variable ${Qt5_VERSION} remains 5.5
+find_package(Qt5 5.9 COMPONENTS Widgets)
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
-
 
 ## System dependencies are found with CMake's conventions
 # find_package(ros_end_effector REQUIRED)
@@ -133,8 +134,13 @@ catkin_package(
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-add_subdirectory(src/chart/)
-add_subdirectory(src/joint_state_gui/)
+#VERSION_GREATER_EQUAL require cmake 3.7, we are using minimum 3.1
+if(Qt5_VERSION VERSION_LESS "5.9")
+
+else()
+    add_subdirectory(src/chart/)
+    add_subdirectory(src/joint_state_gui/)
+endif()
 
 ###########
 ## Build ##
@@ -227,13 +233,18 @@ set_target_properties(${PROJECT_NAME}_gui_main PROPERTIES OUTPUT_NAME "gui_main"
 # add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
+if(Qt5_VERSION VERSION_LESS "5.9")
+
+else()
+    list(APPEND 2tabLibs "joint_bar_ui")
+endif()
+
 target_link_libraries(${PROJECT_NAME}_gui_main
     ${catkin_LIBRARIES}
     Qt5::Widgets
     ${PROJECT_NAME}_MainWindow
     ${PROJECT_NAME}_TimerHandler
-    joint_bar_ui
-
+    ${2tabLibs}
 )
 
 target_link_libraries(${PROJECT_NAME}_MainWindow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
 
+
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
@@ -21,6 +23,9 @@ find_package(catkin REQUIRED COMPONENTS
     rosee_msg
     actionlib
 )
+
+## qt5.12 path to be declared
+set(QT5_PATH "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64")
 
 #not catkin packages
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
@@ -122,6 +127,11 @@ catkin_package(
 #  DEPENDS system_lib
 )
 
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+add_subdirectory(src/chart/)
+add_subdirectory(src/joint_state_gui/)
+
 ###########
 ## Build ##
 ###########
@@ -213,6 +223,8 @@ target_link_libraries(${PROJECT_NAME}_gui_main
     Qt5::Widgets
     ${PROJECT_NAME}_MainWindow
     ${PROJECT_NAME}_TimerHandler
+    joint_bar_ui
+
 )
 
 target_link_libraries(${PROJECT_NAME}_MainWindow
@@ -315,6 +327,12 @@ target_link_libraries(${PROJECT_NAME}_ContainerActionGroupBox
 #   # myfile2
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
+# Mark executables and/or libraries for installation
+#install(TARGETS ${PROJECT_NAME}_gui_main
+#    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+#    )
 
 #############
 ## Testing ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,19 +140,19 @@ add_library(${PROJECT_NAME}_Window SHARED
     include/rosee_gui/Window.h
 )
 
-add_library(${PROJECT_NAME}_ActionLayout SHARED
-    src/ActionLayout.cpp
-    include/rosee_gui/ActionLayout.h
+add_library(${PROJECT_NAME}_SingleActionGroupBox SHARED
+    src/SingleActionGroupBox.cpp
+    include/rosee_gui/SingleActionGroupBox.h
 )
 
-add_library(${PROJECT_NAME}_ActionBoxesLayout SHARED
-    src/ActionBoxesLayout.cpp
-    include/rosee_gui/ActionBoxesLayout.h
+add_library(${PROJECT_NAME}_SingleActionBoxesGroupBox SHARED
+    src/SingleActionBoxesGroupBox.cpp
+    include/rosee_gui/SingleActionBoxesGroupBox.h
 )
 
-add_library(${PROJECT_NAME}_ActionTimedLayout SHARED
-    src/ActionTimedLayout.cpp
-    include/rosee_gui/ActionTimedLayout.h
+add_library(${PROJECT_NAME}_SingleActionTimedGroupBox SHARED
+    src/SingleActionTimedGroupBox.cpp
+    include/rosee_gui/SingleActionTimedGroupBox.h
 )
 
 add_library(${PROJECT_NAME}_ActionTimedElement SHARED
@@ -168,6 +168,16 @@ add_library(${PROJECT_NAME}_TimerHandler SHARED
 add_library(${PROJECT_NAME}_JointStateTable SHARED
     src/JointStateTable.cpp
     include/rosee_gui/JointStateTable.h
+)
+
+add_library(${PROJECT_NAME}_JointStateContainer SHARED
+    src/JointStateContainer.cpp
+    include/rosee_gui/JointStateContainer.h 
+)
+
+add_library(${PROJECT_NAME}_ContainerActionGroupBox SHARED
+    src/ContainerActionGroupBox.cpp
+    include/rosee_gui/ContainerActionGroupBox.h 
 )
 
 
@@ -202,24 +212,22 @@ target_link_libraries(${PROJECT_NAME}_gui_main
 
 target_link_libraries(${PROJECT_NAME}_Window
     ${catkin_LIBRARIES}
-    ${PROJECT_NAME}_ActionLayout
-    ${PROJECT_NAME}_ActionBoxesLayout
-    ${PROJECT_NAME}_ActionTimedLayout
-    ${PROJECT_NAME}_JointStateTable
+    ${PROJECT_NAME}_ContainerActionGroupBox
+    ${PROJECT_NAME}_JointStateContainer
 )
 
 
-target_link_libraries(${PROJECT_NAME}_ActionLayout
+target_link_libraries(${PROJECT_NAME}_SingleActionGroupBox
     ${catkin_LIBRARIES}
     Qt5::Widgets
 )
 
-target_link_libraries(${PROJECT_NAME}_ActionBoxesLayout
+target_link_libraries(${PROJECT_NAME}_SingleActionBoxesGroupBox
     ${catkin_LIBRARIES}
     Qt5::Widgets
 )
 
-target_link_libraries(${PROJECT_NAME}_ActionTimedLayout
+target_link_libraries(${PROJECT_NAME}_SingleActionTimedGroupBox
     ${catkin_LIBRARIES}
     Qt5::Widgets
     ${PROJECT_NAME}_ActionTimedElement
@@ -240,8 +248,18 @@ target_link_libraries(${PROJECT_NAME}_JointStateTable
     Qt5::Widgets
 )
 
-
-
+target_link_libraries(${PROJECT_NAME}_JointStateContainer
+    ${catkin_LIBRARIES}
+    Qt5::Widgets
+    ${PROJECT_NAME}_JointStateTable
+)
+target_link_libraries(${PROJECT_NAME}_ContainerActionGroupBox
+    ${catkin_LIBRARIES}
+    Qt5::Widgets
+    ${PROJECT_NAME}_SingleActionGroupBox
+    ${PROJECT_NAME}_SingleActionBoxesGroupBox
+    ${PROJECT_NAME}_SingleActionTimedGroupBox
+)
 
 #############
 ## Install ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_AUTOUIC ON)
 
 ## qt5.12 path to be declared
 #set(QT5_PATH "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64")
-set(QT5_PATH "" CACHE PATH "Path to QT > 5.9")
-set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT5_PATH}")
+#set(QT5_PATH "" CACHE PATH "Path to QT > 5.9")
+#set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT5_PATH}")
 
 
 if(CMAKE_VERSION VERSION_LESS "3.7.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ target_link_libraries(${PROJECT_NAME}_gui_main
 target_link_libraries(${PROJECT_NAME}_MainWindow
     ${catkin_LIBRARIES}
     Qt5::Widgets
+    ${PROJECT_NAME}_Window
 
 )
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,26 @@
 # rosee_gui
-Gui things for [ROSEE](https://github.com/ADVRHumanoids/ROSEndEffector) project
+This package is a tool for [ROS End-Effector](https://advrhumanoids.github.io/ROSEndEffector/) framework
 
-## Requisite
-QT5
+The ROS End-Effector main documentation is here: https://advrhumanoids.github.io/ROSEndEffectorDocs/, where you can find information about this GUI.
 
-## To launch
-~~~~bash
-roslaunch rosee_gui gui.launch
-~~~~
 
-### How it works - code structure (obviously improvable)
-- **main.cpp** : It handles ROS (creating the nodehandle) and the Qapplication. It creates the Window object
-- **Window.cpp** a *QWidget* derived class which refers to the gui Window. It has as member a *QGridLayout*, and it creates all the inner *QGridLayout* (one for each action)
-- **ActionLayout.cpp** *QGridLayout* derived class, which contain labels buttons and other widgets. It also send message to ros topic, handling a ros publisher with a nodehandle passed to its costructor
-- **ActionBoxesLayout.cpp** Derived class from above, it includes checkboxes to select finger/joint and send them also with topics. 
-- **ActionTimedLayout.cpp**, **ActionTimedElement.cpp** Container and element for the timed action, which per definition is composed by other actions executed one after another with some time margins. Each element has three progress bar so in the future we can take feedback and display a progress of the action execution, included time margins
+***
+<!-- 
+    ROSIN acknowledgement from the ROSIN press kit
+    @ https://github.com/rosin-project/press_kit
+-->
+
+<a href="http://rosin-project.eu">
+  <img src="http://rosin-project.eu/wp-content/uploads/rosin_ack_logo_wide.png" 
+       alt="rosin_logo" height="60" >
+</a>
+
+Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.  
+More information: <a href="http://rosin-project.eu">rosin-project.eu</a>
+
+<img src="http://rosin-project.eu/wp-content/uploads/rosin_eu_flag.jpg" 
+     alt="eu_flag" height="45" align="left" >  
+
+This project has received funding from the European Union’s Horizon 2020  
+research and innovation programme under grant agreement no. 732287. 
+

--- a/include/rosee_gui/ActionTimedElement.h
+++ b/include/rosee_gui/ActionTimedElement.h
@@ -36,6 +36,8 @@ public:
     explicit ActionTimedElement(std::string actionName, double before, double after, QWidget* parent);
     
     void setProgressBarValue(double);
+    
+    void resetAll();
 
 private: 
     QProgressBar* bar;

--- a/include/rosee_gui/ContainerActionGroupBox.h
+++ b/include/rosee_gui/ContainerActionGroupBox.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CONTAINERACTIONGROUPBOX_H
+#define CONTAINERACTIONGROUPBOX_H
+
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QWidget>
+#include <memory.h>
+
+#include <rosee_gui/SingleActionBoxesGroupBox.h>
+#include <rosee_gui/SingleActionGroupBox.h>
+#include <rosee_gui/SingleActionTimedGroupBox.h>
+
+#include <rosee_msg/ActionsInfo.h>
+#include <rosee_msg/SelectablePairInfo.h>
+#include <ROSEndEffector/Action.h>
+
+/**
+ * @todo write docs
+ */
+class ContainerActionGroupBox : public QGroupBox
+{
+
+    Q_OBJECT
+
+public:
+    
+    explicit ContainerActionGroupBox (ros::NodeHandle* nh, QWidget* parent = 0);
+    
+private:
+    QGridLayout *grid;
+    ros::NodeHandle* nh;
+    std::vector <rosee_msg::ActionInfo> actionInfoVect;
+    QPushButton *resetButton;
+
+    
+    std::map < std::string, std::vector<std::string> > getPairMap(
+        std::string action_name, std::vector<std::string> elements);
+    
+    void getInfoServices() ;
+
+private slots:
+    void resetButtonClicked();
+    
+};
+
+#endif // CONTAINERACTIONGROUPBOX_H

--- a/include/rosee_gui/ContainerActionGroupBox.h
+++ b/include/rosee_gui/ContainerActionGroupBox.h
@@ -28,7 +28,7 @@
 
 #include <rosee_msg/ActionsInfo.h>
 #include <rosee_msg/SelectablePairInfo.h>
-#include <ROSEndEffector/Action.h>
+#include <ros_end_effector/Action.h>
 
 /**
  * @todo write docs

--- a/include/rosee_gui/JointStateContainer.h
+++ b/include/rosee_gui/JointStateContainer.h
@@ -21,6 +21,7 @@
 #include <QVBoxLayout>
 #include <QCheckBox>
 #include <QGridLayout>
+#include <QLabel>
 
 #include <rosee_gui/JointStateTable.h>
 #include <rosee_gui/RobotDescriptionHandler.h>
@@ -46,8 +47,14 @@ public slots:
     void showPassiveJoints (int);
     
 private: 
-    JointStateTable* jointStateTable;
-    std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler;
+    JointStateTable* activeJointStateTable;
+    JointStateTable* mimicJointStateTable;
+    JointStateTable* passiveJointStateTable;
+    
+    QLabel* activeJointslabel;
+    QLabel* mimicJointslabel;
+    QLabel* passiveJointslabel;
+
 };
 
 #endif // JOINTSTATECONTAINER_H

--- a/include/rosee_gui/JointStateContainer.h
+++ b/include/rosee_gui/JointStateContainer.h
@@ -41,9 +41,13 @@ public slots:
     void showPositionCol (int);
     void showVelocityCol (int);
     void showEffortCol (int);
+    void showActuatedJoints(int);
+    void showMimicJoints(int);
+    void showPassiveJoints (int);
     
 private: 
     JointStateTable* jointStateTable;
+    std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler;
 };
 
 #endif // JOINTSTATECONTAINER_H

--- a/include/rosee_gui/JointStateContainer.h
+++ b/include/rosee_gui/JointStateContainer.h
@@ -14,32 +14,30 @@
  * limitations under the License.
  */
 
-#ifndef JOINTSTATETABLE_H
-#define JOINTSTATETABLE_H
+#ifndef JOINTSTATECONTAINER_H
+#define JOINTSTATECONTAINER_H
 
 #include <QWidget>
-#include <QTableWidget>
+#include <QVBoxLayout>
+#include <QCheckBox>
+#include <QGridLayout>
+
+#include <rosee_gui/JointStateTable.h>
 
 #include <ros/ros.h>
-#include <sensor_msgs/JointState.h>
 
 /**
  * @todo write docs
  */
-class JointStateTable : public QTableWidget
+class JointStateContainer : public QVBoxLayout
 {
     Q_OBJECT
     
 public:
-    explicit JointStateTable(ros::NodeHandle* nh, int rows = 0 , int columns = 0, QWidget *parent = nullptr);
+    explicit JointStateContainer(ros::NodeHandle* nh, QWidget *parent = nullptr);
     
-private:
-    bool setJointStateSub(ros::NodeHandle* nh);
-    void jointStateClbk ( const sensor_msgs::JointStateConstPtr& msg );
-    
-    ros::Subscriber jointPosSub;
-    sensor_msgs::JointState jointStateMsg;
-    
+private: 
+    JointStateTable* jointStateTable;
 };
 
-#endif // JOINTSTATETABLE_H
+#endif // JOINTSTATECONTAINER_H

--- a/include/rosee_gui/JointStateContainer.h
+++ b/include/rosee_gui/JointStateContainer.h
@@ -23,6 +23,7 @@
 #include <QGridLayout>
 
 #include <rosee_gui/JointStateTable.h>
+#include <rosee_gui/RobotDescriptionHandler.h>
 
 #include <ros/ros.h>
 
@@ -34,7 +35,12 @@ class JointStateContainer : public QVBoxLayout
     Q_OBJECT
     
 public:
-    explicit JointStateContainer(ros::NodeHandle* nh, QWidget *parent = nullptr);
+    explicit JointStateContainer(ros::NodeHandle* nh,  std::shared_ptr<RobotDescriptionHandler>, QWidget *parent = nullptr);
+    
+public slots:
+    void showPositionCol (int);
+    void showVelocityCol (int);
+    void showEffortCol (int);
     
 private: 
     JointStateTable* jointStateTable;

--- a/include/rosee_gui/JointStateTable.h
+++ b/include/rosee_gui/JointStateTable.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JOINTSTATETABLE_H
+#define JOINTSTATETABLE_H
+
+#include <QWidget>
+#include <QTableWidget>
+
+
+/**
+ * @todo write docs
+ */
+class JointStateTable : public QTableWidget
+{
+    Q_OBJECT
+    
+public:
+    explicit JointStateTable(int rows, int columns, QWidget *parent = nullptr);
+    
+};
+
+#endif // JOINTSTATETABLE_H

--- a/include/rosee_gui/JointStateTable.h
+++ b/include/rosee_gui/JointStateTable.h
@@ -23,6 +23,8 @@
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h>
 
+#include <rosee_gui/RobotDescriptionHandler.h>
+
 /**
  * @todo write docs
  */
@@ -31,7 +33,9 @@ class JointStateTable : public QTableWidget
     Q_OBJECT
     
 public:
-    explicit JointStateTable(ros::NodeHandle* nh, int rows = 0 , int columns = 0, QWidget *parent = nullptr);
+    explicit JointStateTable(ros::NodeHandle* nh, 
+                             std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler, 
+                             QWidget *parent = nullptr);
     
 private:
     bool setJointStateSub(ros::NodeHandle* nh);
@@ -39,6 +43,8 @@ private:
     
     ros::Subscriber jointPosSub;
     sensor_msgs::JointState jointStateMsg;
+    
+    std::map <std::string, int> jointNameRowMap;
     
 };
 

--- a/include/rosee_gui/JointStateTable.h
+++ b/include/rosee_gui/JointStateTable.h
@@ -34,7 +34,7 @@ class JointStateTable : public QTableWidget
     
 public:
     explicit JointStateTable(ros::NodeHandle* nh, 
-                             std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler, 
+                             std::map<std::string, ROSEE::JointActuatedType> jointMap,
                              QWidget *parent = nullptr);
     
 private:

--- a/include/rosee_gui/JointStateTable.h
+++ b/include/rosee_gui/JointStateTable.h
@@ -34,7 +34,7 @@ class JointStateTable : public QTableWidget
     
 public:
     explicit JointStateTable(ros::NodeHandle* nh, 
-                             std::map<std::string, ROSEE::JointActuatedType> jointMap,
+                             std::vector<std::string> jointNames,
                              QWidget *parent = nullptr);
     
 private:

--- a/include/rosee_gui/MainWindow.h
+++ b/include/rosee_gui/MainWindow.h
@@ -25,8 +25,14 @@
 
 /**
  * @todo write docs
+ * 
+ * We declare directly the main window as the qtab widget. 
+ * The alternative would be declare it as QWidget and then use a QTabWidget
+ * as a member, then creating a layout... Not necessary now, because we only have one
+ * son. In future, if we want to add something external to the tab widget, we will
+ * use this approach (that is more similar to the qdialog qt tutorial)
  */
-class MainWindow : public  QWidget
+class MainWindow : public  QTabWidget
 {
     Q_OBJECT
     
@@ -34,7 +40,6 @@ public:
     explicit MainWindow(ros::NodeHandle* nh, QWidget *parent = 0);
 
 private:
-    QTabWidget *tabWidget;
 
 };
 

--- a/include/rosee_gui/MainWindow.h
+++ b/include/rosee_gui/MainWindow.h
@@ -22,6 +22,7 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <rosee_gui/TabAction.h>
+#include "../../src/joint_state_gui/joint_monitor_widget.h"
 
 /**
  * @todo write docs

--- a/include/rosee_gui/MainWindow.h
+++ b/include/rosee_gui/MainWindow.h
@@ -20,6 +20,7 @@
 #include <ros/ros.h>
 #include <QWidget>
 #include <QTabWidget>
+#include <QVBoxLayout>
 #include <rosee_gui/Window.h>
 
 /**

--- a/include/rosee_gui/MainWindow.h
+++ b/include/rosee_gui/MainWindow.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <ros/ros.h>
+#include <QWidget>
+#include <QTabWidget>
+#include <rosee_gui/Window.h>
+
+/**
+ * @todo write docs
+ */
+class MainWindow : public  QWidget
+{
+    Q_OBJECT
+    
+public:
+    explicit MainWindow(ros::NodeHandle* nh, QWidget *parent = 0);
+
+private:
+    QTabWidget *tabWidget;
+
+};
+
+
+#endif // MAINWINDOW_H
+

--- a/include/rosee_gui/MainWindow.h
+++ b/include/rosee_gui/MainWindow.h
@@ -21,7 +21,7 @@
 #include <QWidget>
 #include <QTabWidget>
 #include <QVBoxLayout>
-#include <rosee_gui/Window.h>
+#include <rosee_gui/TabAction.h>
 
 /**
  * @todo write docs

--- a/include/rosee_gui/MainWindow.h
+++ b/include/rosee_gui/MainWindow.h
@@ -22,6 +22,10 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <rosee_gui/TabAction.h>
+
+#include <rosee_gui/RobotDescriptionHandler.h>
+
+//TODO solve this
 #include "../../src/joint_state_gui/joint_monitor_widget.h"
 
 /**
@@ -41,6 +45,7 @@ public:
     explicit MainWindow(ros::NodeHandle* nh, QWidget *parent = 0);
 
 private:
+    std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler;
 
 };
 

--- a/include/rosee_gui/MainWindow.h
+++ b/include/rosee_gui/MainWindow.h
@@ -18,6 +18,7 @@
 #define MAINWINDOW_H
 
 #include <ros/ros.h>
+#include <QtGlobal> //for QT_VERSION flag
 #include <QWidget>
 #include <QTabWidget>
 #include <QVBoxLayout>
@@ -25,8 +26,10 @@
 
 #include <rosee_gui/RobotDescriptionHandler.h>
 
-//TODO solve this
-#include "../../src/joint_state_gui/joint_monitor_widget.h"
+#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
+    //TODO solve this relative include
+    #include "../../src/joint_state_gui/joint_monitor_widget.h"
+#endif
 
 /**
  * @todo write docs

--- a/include/rosee_gui/RobotDescriptionHandler.h
+++ b/include/rosee_gui/RobotDescriptionHandler.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ROBOTDESCRIPTIONHANDLER_H
+#define ROBOTDESCRIPTIONHANDLER_H
+
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <urdf_parser/urdf_parser.h>
+#include <srdfdom/model.h>
+
+/**
+ * @todo write docs
+ */
+class RobotDescriptionHandler
+{
+    
+public:
+    //RobotDescriptorHandler();
+    RobotDescriptionHandler(std::string urdfFile );
+    RobotDescriptionHandler(std::string urdfFile, std::string srdfFile );
+    
+    urdf::ModelInterfaceSharedPtr getUrdfModel();
+    srdf::ModelSharedPtr getSrdfModel();
+    
+    std::string getUrdfFile();
+    std::string getSrdfFile();
+    
+private:
+    
+    std::string _urdfFile;
+    std::string _srdfFile;
+    
+    urdf::ModelInterfaceSharedPtr _urdfModel;
+    srdf::ModelSharedPtr _srdfModel;
+    
+};
+
+#endif // ROBOTDESCRIPTIONHANDLER_H

--- a/include/rosee_gui/RobotDescriptionHandler.h
+++ b/include/rosee_gui/RobotDescriptionHandler.h
@@ -22,6 +22,13 @@
 #include <urdf_parser/urdf_parser.h>
 #include <srdfdom/model.h>
 
+
+namespace ROSEE {
+    //for parsing thing of main package, a joint can be OR passive OR mimic, not both
+    //PASSIVE is simply a not actuated joint that other actuated one will not influence
+    enum JointActuatedType { ACTUATED, MIMIC, PASSIVE };
+}
+
 /**
  * @todo write docs
  */
@@ -30,23 +37,28 @@ class RobotDescriptionHandler
     
 public:
     //RobotDescriptorHandler();
-    RobotDescriptionHandler(std::string urdfFile );
+    //RobotDescriptionHandler(std::string urdfFile );
     RobotDescriptionHandler(std::string urdfFile, std::string srdfFile );
     
     urdf::ModelInterfaceSharedPtr getUrdfModel();
     srdf::ModelSharedPtr getSrdfModel();
-    
     std::string getUrdfFile();
     std::string getSrdfFile();
     
+    std::map <std::string, ROSEE::JointActuatedType> getActuatedJointsMap();
+    
 private:
     
+    void look4ActuatedJoints();
+
     std::string _urdfFile;
     std::string _srdfFile;
-    
     urdf::ModelInterfaceSharedPtr _urdfModel;
     srdf::ModelSharedPtr _srdfModel;
     
+    std::map <std::string, ROSEE::JointActuatedType> _actuatedJointsMap;
+    
+
 };
 
 #endif // ROBOTDESCRIPTIONHANDLER_H

--- a/include/rosee_gui/RobotDescriptionHandler.h
+++ b/include/rosee_gui/RobotDescriptionHandler.h
@@ -26,7 +26,7 @@
 namespace ROSEE {
     //for parsing thing of main package, a joint can be OR passive OR mimic, not both
     //PASSIVE is simply a not actuated joint that other actuated one will not influence
-    enum JointActuatedType { ACTUATED, MIMIC, PASSIVE };
+    enum JointActuatedType { ACTIVE, MIMIC, PASSIVE };
 }
 
 /**
@@ -45,7 +45,11 @@ public:
     std::string getUrdfFile();
     std::string getSrdfFile();
     
-    std::map <std::string, ROSEE::JointActuatedType> getActuatedJointsMap();
+    std::map <std::string, ROSEE::JointActuatedType> getActuatedTypeJointsMap();
+    std::vector<std::string> getJointsByActuatedType(ROSEE::JointActuatedType type);
+    std::vector <std::string> getAllJoints();
+
+
     
 private:
     
@@ -56,7 +60,12 @@ private:
     urdf::ModelInterfaceSharedPtr _urdfModel;
     srdf::ModelSharedPtr _srdfModel;
     
-    std::map <std::string, ROSEE::JointActuatedType> _actuatedJointsMap;
+    std::map <std::string, ROSEE::JointActuatedType> _actuatedTypeJointsMap;
+    
+    std::vector <std::string> _activeJoints;
+    std::vector <std::string> _passiveJoints;
+    std::vector <std::string> _mimicJoints;
+    std::vector <std::string> _allJoints;
     
 
 };

--- a/include/rosee_gui/SingleActionBoxesGroupBox.h
+++ b/include/rosee_gui/SingleActionBoxesGroupBox.h
@@ -1,7 +1,7 @@
-#ifndef ACTIONBOXESLAYOUT_H
-#define ACTIONBOXESLAYOUT_H
+#ifndef SINGLEACTIONBOXESGROUPBOX_H
+#define SINGLEACTIONBOXESGROUPBOX_H
 
-#include <rosee_gui/ActionLayout.h>
+#include <rosee_gui/SingleActionGroupBox.h>
 
 #include <QWidget>
 #include <QGroupBox>
@@ -12,13 +12,15 @@
 #include <rosee_msg/ActionInfo.h> //msg
 #include <ROSEndEffector/ActionPrimitive.h>
 
-class ActionBoxesLayout : public ActionLayout
+class SingleActionBoxesGroupBox : public SingleActionGroupBox
 {
     Q_OBJECT
 public:
-    explicit ActionBoxesLayout(ros::NodeHandle* nh, rosee_msg::ActionInfo,  QWidget* parent=0);
-    explicit ActionBoxesLayout(ros::NodeHandle* nh, rosee_msg::ActionInfo,
+    explicit SingleActionBoxesGroupBox(ros::NodeHandle* nh, rosee_msg::ActionInfo,  QWidget* parent=0);
+    explicit SingleActionBoxesGroupBox(ros::NodeHandle* nh, rosee_msg::ActionInfo,
                                std::map<std::string, std::vector<std::string>> pairedMap, QWidget* parent=0);
+        
+    virtual void resetAll() override;
 
 private:
     QButtonGroup* boxes;
@@ -45,4 +47,4 @@ private slots:
 
 };
 
-#endif // ACTIONBOXESLAYOUT_H
+#endif // SINGLEACTIONBOXESGROUPBOX_H

--- a/include/rosee_gui/SingleActionBoxesGroupBox.h
+++ b/include/rosee_gui/SingleActionBoxesGroupBox.h
@@ -10,7 +10,7 @@
 #include <ros/ros.h>
 
 #include <rosee_msg/ActionInfo.h> //msg
-#include <ROSEndEffector/ActionPrimitive.h>
+#include <ros_end_effector/ActionPrimitive.h>
 
 class SingleActionBoxesGroupBox : public SingleActionGroupBox
 {

--- a/include/rosee_gui/SingleActionGroupBox.h
+++ b/include/rosee_gui/SingleActionGroupBox.h
@@ -1,5 +1,5 @@
-#ifndef ACTIONLAYOUT_H
-#define ACTIONLAYOUT_H
+#ifndef SINGLEACTIONGROUPBOX_H
+#define SINGLEACTIONGROUPBOX_H
 
 #include <QWidget>
 #include <QPushButton>
@@ -27,11 +27,13 @@
 /**
  * TODO better to pass a pub pointer to have only a single publisher for all gui?
  */
-class ActionLayout: public QGroupBox
+class SingleActionGroupBox: public QGroupBox
 {
     Q_OBJECT
 public:
-    explicit ActionLayout(ros::NodeHandle *nh, rosee_msg::ActionInfo, QWidget* parent=0);
+    explicit SingleActionGroupBox(ros::NodeHandle *nh, rosee_msg::ActionInfo, QWidget* parent=0);
+    
+    virtual void resetAll();
         
 protected:
     QGridLayout *grid;
@@ -41,6 +43,7 @@ protected:
 
     QPushButton *send_button; //protected so derived class can enable/disable if necessary
     std::shared_ptr <actionlib::SimpleActionClient <rosee_msg::ROSEECommandAction> > action_client;
+
     void doneCallback(const actionlib::SimpleClientGoalState& state,
             const rosee_msg::ROSEECommandResultConstPtr& result);
     void activeCallback();
@@ -51,6 +54,7 @@ protected:
      * @return (0.0 - 1.0 double) the percentage displayed in the spinBox. The spinBox and slider have a syncro-same value
      */
     double getSpinBoxPercentage();
+    
 
 private:
     QSlider *slider_percentage;
@@ -61,15 +65,12 @@ private:
     void setRosActionClient ( ros::NodeHandle * nh, std::string rosActionName);
     
 
-
-
 signals:
 
 private slots:
     void slotSliderReceive(int value);
     void sendBtnClicked();
 
-
 };
 
-#endif // ACTIONLAYOUT_H
+#endif // SINGLEACTIONGROUPBOX_H

--- a/include/rosee_gui/SingleActionGroupBox.h
+++ b/include/rosee_gui/SingleActionGroupBox.h
@@ -62,7 +62,7 @@ private:
     QProgressBar *progressBar;
 
     virtual void sendActionRos();
-    void setRosActionClient ( ros::NodeHandle * nh, std::string rosActionName);
+    void setRosActionClient ( ros::NodeHandle * nh);
     
 
 signals:

--- a/include/rosee_gui/SingleActionGroupBox.h
+++ b/include/rosee_gui/SingleActionGroupBox.h
@@ -19,8 +19,8 @@
 
 #include <rosee_msg/ROSEECommandAction.h>
 #include <rosee_msg/ActionInfo.h> //msg
-#include <ROSEndEffector/Action.h>
-#include <ROSEndEffector/ActionPrimitive.h>
+#include <ros_end_effector/Action.h>
+#include <ros_end_effector/ActionPrimitive.h>
 
 #include <actionlib/client/simple_action_client.h>
 

--- a/include/rosee_gui/SingleActionTimedGroupBox.h
+++ b/include/rosee_gui/SingleActionTimedGroupBox.h
@@ -60,7 +60,7 @@ private:
     std::string actionName;
     
     virtual void sendActionRos();
-    void setRosActionClient ( ros::NodeHandle * nh, std::string rosActionName);
+    void setRosActionClient ( ros::NodeHandle * nh);
 
 private slots:
     void sendBtnClicked();

--- a/include/rosee_gui/SingleActionTimedGroupBox.h
+++ b/include/rosee_gui/SingleActionTimedGroupBox.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef ACTIONTIMEDLAYOUT_H
-#define ACTIONTIMEDLAYOUT_H
+#ifndef SINGLEACTIONTIMEDGROUPBOX_H
+#define SINGLEACTIONTIMEDGROUPBOX_H
 
 #include <iostream>
 
@@ -31,16 +31,16 @@
 
 #include <actionlib/client/simple_action_client.h>
 
-#include <rosee_gui/ActionLayout.h> //TODO remove when solve problem with type from rosee pkg
+#include <rosee_gui/SingleActionGroupBox.h> //TODO remove when solve problem with type from rosee pkg
 
 /**
  * @todo write docs
  */
-class ActionTimedLayout : public QGroupBox {
+class SingleActionTimedGroupBox : public QGroupBox {
     
     Q_OBJECT
 public :
-    explicit ActionTimedLayout (ros::NodeHandle* nh, rosee_msg::ActionInfo actInfo,
+    explicit SingleActionTimedGroupBox (ros::NodeHandle* nh, rosee_msg::ActionInfo actInfo,
                                 QWidget* parent = 0);
     
     std::shared_ptr <actionlib::SimpleActionClient <rosee_msg::ROSEECommandAction> > action_client;
@@ -48,6 +48,8 @@ public :
             const rosee_msg::ROSEECommandResultConstPtr& result);
     void activeCallback();
     void feedbackCallback(const rosee_msg::ROSEECommandFeedbackConstPtr& feedback);
+    
+    void resetAll();
 
 private: 
     QGridLayout *grid;
@@ -65,4 +67,4 @@ private slots:
     
 };
 
-#endif // ACTIONTIMEDLAYOUT_H
+#endif // SINGLEACTIONTIMEDGROUPBOX_H

--- a/include/rosee_gui/TabAction.h
+++ b/include/rosee_gui/TabAction.h
@@ -7,12 +7,13 @@
 
 #include <rosee_gui/JointStateContainer.h>
 #include <rosee_gui/ContainerActionGroupBox.h>
+#include <rosee_gui/RobotDescriptionHandler.h>
 
 class TabAction : public QWidget
 {
     Q_OBJECT
 public:
-    explicit TabAction(ros::NodeHandle* nh, QWidget *parent = 0);
+    explicit TabAction(ros::NodeHandle* nh, std::shared_ptr<RobotDescriptionHandler>,  QWidget *parent = 0);
     
 private:
     ros::NodeHandle* nh;

--- a/include/rosee_gui/TabAction.h
+++ b/include/rosee_gui/TabAction.h
@@ -1,5 +1,5 @@
-#ifndef WINDOW_H
-#define WINDOW_H
+#ifndef TABACTION_H
+#define TABACTION_H
 
 #include <QWidget>
 #include <QGridLayout>
@@ -8,11 +8,11 @@
 #include <rosee_gui/JointStateContainer.h>
 #include <rosee_gui/ContainerActionGroupBox.h>
 
-class Window : public QWidget
+class TabAction : public QWidget
 {
     Q_OBJECT
 public:
-    explicit Window(ros::NodeHandle* nh, QWidget *parent = 0);
+    explicit TabAction(ros::NodeHandle* nh, QWidget *parent = 0);
     
 private:
     ros::NodeHandle* nh;
@@ -34,4 +34,4 @@ public slots:
     
 };
 
-#endif // WINDOW_H
+#endif // TABACTION_H

--- a/include/rosee_gui/Window.h
+++ b/include/rosee_gui/Window.h
@@ -3,15 +3,11 @@
 
 #include <QWidget>
 #include <QGridLayout>
+#include <QGroupBox>
 
-#include <rosee_gui/ActionBoxesLayout.h>
-#include <rosee_gui/ActionLayout.h>
-#include <rosee_gui/ActionTimedLayout.h>
-#include <rosee_gui/JointStateTable.h>
 
-#include <rosee_msg/ActionsInfo.h>
-#include <rosee_msg/SelectablePairInfo.h>
-#include <ROSEndEffector/Action.h>
+#include <rosee_gui/JointStateContainer.h>
+#include <rosee_gui/ContainerActionGroupBox.h>
 
 class Window : public QWidget
 {
@@ -21,18 +17,16 @@ public:
     
 private:
     ros::NodeHandle* nh;
-    std::vector <rosee_msg::ActionInfo> actionInfoVect;
+    ContainerActionGroupBox* containerActionGroupBox;
     
-    QGridLayout* actionContainerLayout;
     QGroupBox* actionGroupBox;
     void createActionGroupBox();
     
-    JointStateTable* jointStateTable;
-    void createJointStateTable();
+    JointStateContainer* jointStateContainer;
+    void createJointStateContainer();
     
-    void getInfoServices() ;
-    std::map < std::string, std::vector<std::string> > getPairMap(
-        std::string action_name, std::vector<std::string> elements);
+
+
 
 signals:
 

--- a/include/rosee_gui/Window.h
+++ b/include/rosee_gui/Window.h
@@ -5,15 +5,8 @@
 #include <QGridLayout>
 #include <QGroupBox>
 
-
-<<<<<<< HEAD
 #include <rosee_gui/JointStateContainer.h>
 #include <rosee_gui/ContainerActionGroupBox.h>
-=======
-#include <rosee_msg/ActionsInfo.h>
-#include <rosee_msg/SelectablePairInfo.h>
-#include <ros_end_effector/Action.h>
->>>>>>> bc173cb... refactor to a single package name convention (with underscores)
 
 class Window : public QWidget
 {

--- a/include/rosee_gui/Window.h
+++ b/include/rosee_gui/Window.h
@@ -6,8 +6,14 @@
 #include <QGroupBox>
 
 
+<<<<<<< HEAD
 #include <rosee_gui/JointStateContainer.h>
 #include <rosee_gui/ContainerActionGroupBox.h>
+=======
+#include <rosee_msg/ActionsInfo.h>
+#include <rosee_msg/SelectablePairInfo.h>
+#include <ros_end_effector/Action.h>
+>>>>>>> bc173cb... refactor to a single package name convention (with underscores)
 
 class Window : public QWidget
 {

--- a/include/rosee_gui/Window.h
+++ b/include/rosee_gui/Window.h
@@ -7,6 +7,7 @@
 #include <rosee_gui/ActionBoxesLayout.h>
 #include <rosee_gui/ActionLayout.h>
 #include <rosee_gui/ActionTimedLayout.h>
+#include <rosee_gui/JointStateTable.h>
 
 #include <rosee_msg/ActionsInfo.h>
 #include <rosee_msg/SelectablePairInfo.h>
@@ -22,6 +23,13 @@ private:
     ros::NodeHandle* nh;
     std::vector <rosee_msg::ActionInfo> actionInfoVect;
     
+    QGridLayout* actionContainerLayout;
+    QGroupBox* actionGroupBox;
+    void createActionGroupBox();
+    
+    JointStateTable* jointStateTable;
+    void createJointStateTable();
+    
     void getInfoServices() ;
     std::map < std::string, std::vector<std::string> > getPairMap(
         std::string action_name, std::vector<std::string> elements);
@@ -29,6 +37,8 @@ private:
 signals:
 
 public slots:
+    
+    
 };
 
 #endif // WINDOW_H

--- a/launch/gui.launch
+++ b/launch/gui.launch
@@ -4,5 +4,5 @@
 
      <node unless="$(arg gdb)" type="gui_main" name="gui_main" pkg="rosee_gui" output="screen"/> 
      
-     <node if="$(arg gdb)" type="gui_main" name="gui_main" pkg="rosee_gui" output="screen" launch-prefix="xterm -e gdb --args"/>
+     <node if="$(arg gdb)" type="gui_main" name="gui_main" pkg="rosee_gui" output="screen" launch-prefix="gdb -ex run --args"/>
 </launch>

--- a/launch/gui.launch
+++ b/launch/gui.launch
@@ -1,4 +1,8 @@
 <?xml version="1.0"?>
 <launch>
-     <node type="gui_main" name="gui_main" pkg="rosee_gui" output="screen"/> 
+    <arg name="gdb" default="false"/> <!-- for debug with gdb -->
+
+     <node unless="$(arg gdb)" type="gui_main" name="gui_main" pkg="rosee_gui" output="screen"/> 
+     
+     <node if="$(arg gdb)" type="gui_main" name="gui_main" pkg="rosee_gui" output="screen" launch-prefix="xterm -e gdb --args"/>
 </launch>

--- a/launch/guiCopy.launch
+++ b/launch/guiCopy.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<launch>
+    <arg name="gdb" default="false"/> <!-- for debug with gdb -->
+
+     <node unless="$(arg gdb)" type="gui_main" name="gui_main_copy" pkg="rosee_gui" output="screen"/> 
+     
+     <node if="$(arg gdb)" type="gui_main" name="gui_main_copy" pkg="rosee_gui" output="screen" launch-prefix="gdb -ex run --args"/>
+</launch>

--- a/src/ActionTimedElement.cpp
+++ b/src/ActionTimedElement.cpp
@@ -19,7 +19,8 @@
 ActionTimedElement::ActionTimedElement(std::string actionName, 
                                        double before, double after, QWidget* parent ) : QGroupBox(parent) {
     
-    this->setMinimumSize(200,180);
+    this->setMinimumSize(130,130);
+    this->setMaximumSize(200,200);
     
     QGridLayout *grid;
     grid = new QGridLayout();
@@ -27,7 +28,7 @@ ActionTimedElement::ActionTimedElement(std::string actionName,
     QLabel* titleLabel;
     titleLabel = new QLabel (QString::fromStdString(actionName));
     titleLabel->setAlignment(Qt::AlignCenter);
-    titleLabel->setStyleSheet("QLabel { font-size :25px }");
+    titleLabel->setStyleSheet("QLabel { font-size :20px }");
     grid->addWidget(titleLabel, 0, 0);
     
     std::ostringstream beforeStream, afterStream;

--- a/src/ActionTimedElement.cpp
+++ b/src/ActionTimedElement.cpp
@@ -52,3 +52,8 @@ ActionTimedElement::ActionTimedElement(std::string actionName,
 void ActionTimedElement::setProgressBarValue(double value) {
     bar->setValue(value);
 }
+
+void ActionTimedElement::resetAll() {
+    bar->setValue(0);
+}
+

--- a/src/ContainerActionGroupBox.cpp
+++ b/src/ContainerActionGroupBox.cpp
@@ -163,26 +163,14 @@ std::map < std::string, std::vector<std::string> > ContainerActionGroupBox::getP
 void ContainerActionGroupBox::resetButtonClicked() {
     
     auto singleActionGroupBoxs = this->findChildren<SingleActionGroupBox *>();
-    std::cout << "aaaaaaaaaaaaaaaaaaaaaaaaa" << std::endl;
-    ROS_ERROR_STREAM ("Child Are:");
-        for (auto child : findChildren<QWidget *>()) {
-            if (! child->objectName().isNull() ) {
-                ROS_WARN_STREAM (  qPrintable(child->objectName()) );
-
-            } else {
-                ROS_WARN_STREAM ( "nullName" );
-            }
-        }
 
     for (auto it : singleActionGroupBoxs) {
-        std::cout << "BOHOHOHOHO" << std::endl;
         it->resetAll();
     }
     
     auto singleActionTimedGros = this->findChildren<SingleActionTimedGroupBox *>();
     
     for (auto it : singleActionTimedGros) {
-        std::cout << "MAAAAAAAAAAAAAAAA" << std::endl;
 
         it->resetAll();
     }

--- a/src/ContainerActionGroupBox.cpp
+++ b/src/ContainerActionGroupBox.cpp
@@ -96,7 +96,7 @@ ContainerActionGroupBox::ContainerActionGroupBox (ros::NodeHandle* nh, QWidget* 
     }
 
     //special last button to reset all widget and send 0 pos to all joints
-    resetButton = new QPushButton("Reset", this);
+    resetButton = new QPushButton("Reset GUI", this);
     resetButton->setMinimumSize(50,50);
     resetButton->setAutoFillBackground(true);
     QPalette palette = resetButton->palette();

--- a/src/ContainerActionGroupBox.cpp
+++ b/src/ContainerActionGroupBox.cpp
@@ -97,14 +97,16 @@ ContainerActionGroupBox::ContainerActionGroupBox (ros::NodeHandle* nh, QWidget* 
 
     //special last button to reset all widget and send 0 pos to all joints
     resetButton = new QPushButton("Reset GUI", this);
-    resetButton->setMinimumSize(50,50);
+    resetButton->setMinimumSize(150,50);
+    resetButton->setMaximumSize(200,70);
     resetButton->setAutoFillBackground(true);
     QPalette palette = resetButton->palette();
     resetButton->setStyleSheet("QPushButton {background-color: red; color: black;}");
     resetButton->setPalette(palette);
     connect (resetButton, SIGNAL (clicked()), this, SLOT (resetButtonClicked()));
     
-    grid->addWidget(resetButton, rowCol/4, rowCol%4);
+    //we place the button spanning the available space in the row (so, 4-(rowCol/4) )
+    grid->addWidget(resetButton, rowCol/4, rowCol%4, 1, 4-(rowCol/4), Qt::AlignCenter);
     
     this->setLayout(grid);
     

--- a/src/ContainerActionGroupBox.cpp
+++ b/src/ContainerActionGroupBox.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rosee_gui/ContainerActionGroupBox.h>
+
+ContainerActionGroupBox::ContainerActionGroupBox (ros::NodeHandle* nh, QWidget* parent) : QGroupBox(parent) {
+    
+    this->nh = nh;
+    
+    // get (wait) for info from unviersalroseeExecutor about all the action parsed by it
+    getInfoServices();
+    
+    grid = new QGridLayout;
+    int rowCol = 0;
+
+    for (auto actInfo: actionInfoVect) {
+            
+        switch (actInfo.action_type) {
+        
+        case ROSEE::Action::Type::Primitive :
+        {
+            if (actInfo.max_selectable == 2) {
+                // get (wait) for service that provide info of which element can be paired
+                // so in the gui we disable the not pairable checkboxes if one is checked
+                std::map<std::string, std::vector<std::string>> pairedElementMap = 
+                    getPairMap(actInfo.action_name, actInfo.selectable_names);
+                
+                SingleActionBoxesGroupBox* singleActionBoxesGroupBox;
+                if (pairedElementMap.size() != 0) {
+                    singleActionBoxesGroupBox = 
+                    new SingleActionBoxesGroupBox(nh, actInfo, pairedElementMap, this) ;
+                    
+                } else {
+                    //version without disabling the not pairable checkboxes
+                    singleActionBoxesGroupBox = 
+                    new SingleActionBoxesGroupBox(nh, actInfo, this) ; 
+                    
+                }
+                grid->addWidget (singleActionBoxesGroupBox, rowCol/4, rowCol%4);
+                
+            } else {
+                SingleActionBoxesGroupBox* singleActionBoxesGroupBox;
+                singleActionBoxesGroupBox = 
+                    new SingleActionBoxesGroupBox(nh, actInfo, this) ; 
+                grid->addWidget (singleActionBoxesGroupBox, rowCol/4, rowCol%4);
+            }
+
+            break;
+        }
+        case ROSEE::Action::Type::Generic : // same thing as composed
+        case ROSEE::Action::Type::Composed :
+        {
+            SingleActionGroupBox* singleActionGroupBox = new SingleActionGroupBox(nh, actInfo, this);
+            grid->addWidget (singleActionGroupBox, rowCol/4, rowCol%4);
+            break;
+        }
+        case ROSEE::Action::Type::Timed : 
+        {
+            SingleActionTimedGroupBox* timed = new SingleActionTimedGroupBox(nh, actInfo, this);
+            grid->addWidget(timed, rowCol/4, rowCol%4, 1, actInfo.inner_actions.size());
+            
+            //timed action occupy more space in the grid... -1 because +1 increment
+            //is already present at the end of this switch
+            rowCol += (actInfo.inner_actions.size()-1);
+
+            break;
+        }
+        case ROSEE::Action::Type::None :
+        {
+            
+            ROS_ERROR_STREAM ("GUI ERROR, type NONE received for action " << actInfo.action_name);
+            throw "";
+            break;
+        }
+        default : {
+            ROS_ERROR_STREAM ("GUI ERROR, not recognized type " << actInfo.action_type
+            << " received for action " << actInfo.action_name);
+            throw "";
+        }
+        } 
+        
+        rowCol++;
+    }
+
+    //special last button to reset all widget and send 0 pos to all joints
+    resetButton = new QPushButton("Reset", this);
+    resetButton->setMinimumSize(50,50);
+    resetButton->setAutoFillBackground(true);
+    QPalette palette = resetButton->palette();
+    resetButton->setStyleSheet("QPushButton {background-color: red; color: black;}");
+    resetButton->setPalette(palette);
+    connect (resetButton, SIGNAL (clicked()), this, SLOT (resetButtonClicked()));
+    
+    grid->addWidget(resetButton, rowCol/4, rowCol%4);
+    
+    this->setLayout(grid);
+    
+}
+
+
+void ContainerActionGroupBox::getInfoServices() {
+    
+    ros::service::waitForService("ros_end_effector/ActionsInfo"); //blocking infinite wait, it also print
+    
+    rosee_msg::ActionsInfo actionsInfo;
+
+    if (ros::service::call ("ros_end_effector/ActionsInfo", actionsInfo)) {
+        actionInfoVect = actionsInfo.response.actionsInfo;
+    } else {
+        ROS_ERROR_STREAM (" ros::service::call FAILED " );
+    }
+    
+}
+
+
+std::map < std::string, std::vector<std::string> > ContainerActionGroupBox::getPairMap( 
+    std::string action_name, std::vector<std::string> elements) {
+    
+    std::map<std::string, std::vector<std::string>> pairedElementMap;
+    
+    ROS_INFO_STREAM ("waiting for ros_end_effector/SelectablePairInfo service for 5 seconds...");
+    if (! ros::service::waitForService("ros_end_effector/SelectablePairInfo", 5000)) {
+        ROS_WARN_STREAM ("ros_end_effector/SelectablePairInfo not found");
+        return std::map < std::string, std::vector<std::string> >();
+    }
+    ROS_INFO_STREAM ("... service found, I will call it");
+
+    rosee_msg::SelectablePairInfo pairInfo;
+    pairInfo.request.action_name = action_name;
+
+    for (auto elementName : elements) {
+        pairInfo.request.element_name = elementName;
+        if (ros::service::call("ros_end_effector/SelectablePairInfo", pairInfo)) {
+            
+            pairedElementMap.insert(std::make_pair(elementName, pairInfo.response.pair_elements) );
+            
+        } else {
+            ROS_ERROR_STREAM ("ros_end_effector/SelectablePairInfo call failed with " << 
+                pairInfo.request.action_name << ", " << pairInfo.request.element_name <<
+                " as request");
+            return std::map < std::string, std::vector<std::string> >();
+
+        }
+    }
+    return pairedElementMap;
+}
+
+
+//TODO or it is better to store the child and not look for them each time?
+void ContainerActionGroupBox::resetButtonClicked() {
+    
+    auto singleActionGroupBoxs = this->findChildren<SingleActionGroupBox *>();
+    std::cout << "aaaaaaaaaaaaaaaaaaaaaaaaa" << std::endl;
+    ROS_ERROR_STREAM ("Child Are:");
+        for (auto child : findChildren<QWidget *>()) {
+            if (! child->objectName().isNull() ) {
+                ROS_WARN_STREAM (  qPrintable(child->objectName()) );
+
+            } else {
+                ROS_WARN_STREAM ( "nullName" );
+            }
+        }
+
+    for (auto it : singleActionGroupBoxs) {
+        std::cout << "BOHOHOHOHO" << std::endl;
+        it->resetAll();
+    }
+    
+    auto singleActionTimedGros = this->findChildren<SingleActionTimedGroupBox *>();
+    
+    for (auto it : singleActionTimedGros) {
+        std::cout << "MAAAAAAAAAAAAAAAA" << std::endl;
+
+        it->resetAll();
+    }
+    
+    
+}

--- a/src/JointStateContainer.cpp
+++ b/src/JointStateContainer.cpp
@@ -16,28 +16,73 @@
 
 #include <rosee_gui/JointStateContainer.h>
 
-JointStateContainer::JointStateContainer (ros::NodeHandle* nh, QWidget *parent) : QVBoxLayout(parent) {
+JointStateContainer::JointStateContainer (ros::NodeHandle* nh,
+                                          std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler,
+                                          QWidget *parent) : QVBoxLayout(parent) {
  
     jointStateTable = new JointStateTable(nh, 0,0, parent);
     QGridLayout* jointStateTableOptions = new QGridLayout;
     
     QCheckBox* posBox = new QCheckBox ( "position");
     posBox->setToolTip("Check to show position of joints");
+    posBox->setChecked(true);
+    QObject::connect( posBox, SIGNAL (stateChanged(int)), 
+                      this,   SLOT(showPositionCol(int)) );
+    
     QCheckBox* velBox = new QCheckBox ( "velocity");
-    posBox->setToolTip("Check to show velocity of joints");
+    velBox->setToolTip("Check to show velocity of joints");
+    velBox->setChecked(true);
+    QObject::connect( velBox, SIGNAL (stateChanged(int)), 
+                      this,   SLOT(showVelocityCol(int)) );
+    
     QCheckBox* effBox = new QCheckBox ( "effort");
-    posBox->setToolTip("Check to show effort of joints");
-    QCheckBox* actBox = new QCheckBox ( "not actuated joints");
-    posBox->setToolTip("Check to show also the state of not actuated joints");
+    effBox->setToolTip("Check to show effort of joints");
+    effBox->setChecked(true);
+    QObject::connect( effBox, SIGNAL (stateChanged(int)), 
+                      this,   SLOT(showEffortCol(int)) );
+    
+    QCheckBox* nonActBox = new QCheckBox ( "not actuated joints");
+    nonActBox->setToolTip("Check to show also the state of not actuated joints");
+    nonActBox->setChecked(true);
     
     jointStateTableOptions->addWidget(posBox, 0, 0);
     jointStateTableOptions->addWidget(velBox, 0, 1);
     jointStateTableOptions->addWidget(effBox, 0, 2);
-    jointStateTableOptions->addWidget(actBox, 1, 0, 1, 3); //spawn so it is in the middle
+    jointStateTableOptions->addWidget(nonActBox, 1, 0, 1, 3); //spawn so it is in the middle
 
     this->addWidget(jointStateTable);
     this->addLayout(jointStateTableOptions);
     
-    
 }
+
+void JointStateContainer::showPositionCol(int state) {
+    
+    if (state == Qt::Checked) {
+        jointStateTable->setColumnHidden(0, false);
+        
+    } else {
+        jointStateTable->setColumnHidden(0, true);
+    }
+}
+
+void JointStateContainer::showVelocityCol(int state) {
+    
+    if (state == Qt::Checked) {
+        jointStateTable->setColumnHidden(1, false);
+        
+    } else {
+        jointStateTable->setColumnHidden(1, true);
+    }
+}
+
+void JointStateContainer::showEffortCol(int state) {
+    
+    if (state == Qt::Checked) {
+        jointStateTable->setColumnHidden(2, false);
+        
+    } else {
+        jointStateTable->setColumnHidden(2, true);
+    }
+}
+
 

--- a/src/JointStateContainer.cpp
+++ b/src/JointStateContainer.cpp
@@ -20,34 +20,20 @@ JointStateContainer::JointStateContainer (ros::NodeHandle* nh,
                                           std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler,
                                           QWidget *parent) : QVBoxLayout(parent) {
     
+                                              
+    activeJointStateTable = new JointStateTable(
+        nh, 
+        robotDescriptionHandler->getJointsByActuatedType(ROSEE::JointActuatedType::ACTIVE), 
+        parent);
+    mimicJointStateTable = new JointStateTable(
+        nh, 
+        robotDescriptionHandler->getJointsByActuatedType(ROSEE::JointActuatedType::MIMIC), 
+        parent);
+    passiveJointStateTable = new JointStateTable(
+        nh, 
+        robotDescriptionHandler->getJointsByActuatedType(ROSEE::JointActuatedType::PASSIVE), 
+        parent);
 
-    std::map<std::string, ROSEE::JointActuatedType> activeJointMap;
-    std::map<std::string, ROSEE::JointActuatedType> mimicointMap;
-    std::map<std::string, ROSEE::JointActuatedType> passiveJointMap;
-    
-    auto actuatedTypeJointFullMap = robotDescriptionHandler->getActuatedJointsMap();
-
-    for (auto it : actuatedTypeJointFullMap) {
-        switch (it.second){
-        
-            case ROSEE::JointActuatedType::ACTUATED :
-                activeJointMap[it.first] = it.second;
-                break;
-            case ROSEE::JointActuatedType::MIMIC :
-                mimicointMap[it.first] = it.second;
-                break;
-            case ROSEE::JointActuatedType::PASSIVE :
-                passiveJointMap[it.first] = it.second;
-                break;
-            default:
-                break;
-        }
-    }
-                                          
-    activeJointStateTable = new JointStateTable(nh, activeJointMap, parent);
-    mimicJointStateTable = new JointStateTable(nh, mimicointMap, parent);
-    passiveJointStateTable = new JointStateTable(nh, passiveJointMap, parent);
-    
     QGridLayout* jointStateTableOptions = new QGridLayout;
     
     QCheckBox* posBox = new QCheckBox ( "position");

--- a/src/JointStateContainer.cpp
+++ b/src/JointStateContainer.cpp
@@ -60,11 +60,13 @@ JointStateContainer::JointStateContainer (ros::NodeHandle* nh,
     QObject::connect( actuatedBox, SIGNAL (stateChanged(int)), 
                       this,   SLOT(showActuatedJoints(int)) );
     
+    
     QCheckBox* mimicBox = new QCheckBox ( "mimic joints");
     mimicBox->setToolTip("Check to show the state of mimic joints");
     mimicBox->setChecked(true);
     QObject::connect( mimicBox, SIGNAL (stateChanged(int)), 
                       this,   SLOT(showMimicJoints(int)) );
+    
     
     QCheckBox* passiveBox = new QCheckBox ( "passive joints");
     passiveBox->setToolTip("Check to show the state of passive joints");
@@ -99,6 +101,19 @@ JointStateContainer::JointStateContainer (ros::NodeHandle* nh,
     this->addWidget(passiveJointslabel);
     this->addWidget(passiveJointStateTable);
     this->addLayout(jointStateTableOptions);
+    
+    if (robotDescriptionHandler->getJointsByActuatedType(ROSEE::JointActuatedType::ACTIVE).size() == 0) {
+        actuatedBox->click();
+    } 
+    
+    if (robotDescriptionHandler->getJointsByActuatedType(ROSEE::JointActuatedType::MIMIC).size() == 0) {
+        mimicBox->click();
+    } 
+    
+    if (robotDescriptionHandler->getJointsByActuatedType(ROSEE::JointActuatedType::PASSIVE).size() == 0) {
+        passiveBox->click();
+    } 
+    
     
 }
 

--- a/src/JointStateContainer.cpp
+++ b/src/JointStateContainer.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rosee_gui/JointStateContainer.h>
+
+JointStateContainer::JointStateContainer (ros::NodeHandle* nh, QWidget *parent) : QVBoxLayout(parent) {
+ 
+    jointStateTable = new JointStateTable(nh, 0,0, parent);
+    QGridLayout* jointStateTableOptions = new QGridLayout;
+    
+    QCheckBox* posBox = new QCheckBox ( "position");
+    posBox->setToolTip("Check to show position of joints");
+    QCheckBox* velBox = new QCheckBox ( "velocity");
+    posBox->setToolTip("Check to show velocity of joints");
+    QCheckBox* effBox = new QCheckBox ( "effort");
+    posBox->setToolTip("Check to show effort of joints");
+    QCheckBox* actBox = new QCheckBox ( "not actuated joints");
+    posBox->setToolTip("Check to show also the state of not actuated joints");
+    
+    jointStateTableOptions->addWidget(posBox, 0, 0);
+    jointStateTableOptions->addWidget(velBox, 0, 1);
+    jointStateTableOptions->addWidget(effBox, 0, 2);
+    jointStateTableOptions->addWidget(actBox, 1, 0, 1, 3); //spawn so it is in the middle
+
+    this->addWidget(jointStateTable);
+    this->addLayout(jointStateTableOptions);
+    
+    
+}
+

--- a/src/JointStateTable.cpp
+++ b/src/JointStateTable.cpp
@@ -18,7 +18,7 @@
 #include <qheaderview.h> //to modify font size
 
 JointStateTable::JointStateTable (ros::NodeHandle* nh, 
-                                   std::map<std::string, ROSEE::JointActuatedType> jointMap, QWidget *parent) :
+                                   std::vector<std::string> jointNames, QWidget *parent) :
     QTableWidget(0, 0, parent) {
         
     if (setJointStateSub(nh)) {
@@ -49,12 +49,12 @@ JointStateTable::JointStateTable (ros::NodeHandle* nh,
         horizontalFont.setPointSize(8);
         this->horizontalHeader()->setFont(horizontalFont);
 
-        this->setRowCount(jointMap.size());
+        this->setRowCount(jointNames.size());
         
         int row = 0;
-        for (auto mapEl : jointMap) {
+        for (auto joint : jointNames) {
             
-            QTableWidgetItem* labelWidget = new QTableWidgetItem(QString::fromStdString(mapEl.first));
+            QTableWidgetItem* labelWidget = new QTableWidgetItem(QString::fromStdString(joint));
 
             setVerticalHeaderItem(row, labelWidget);
             
@@ -65,7 +65,7 @@ JointStateTable::JointStateTable (ros::NodeHandle* nh,
 
             
             //we need this to update the correct row in the callback
-            jointNameRowMap[mapEl.first] = row;
+            jointNameRowMap[joint] = row;
             row++;
         }
 

--- a/src/JointStateTable.cpp
+++ b/src/JointStateTable.cpp
@@ -18,7 +18,7 @@
 #include <qheaderview.h> //to modify font size
 
 JointStateTable::JointStateTable (ros::NodeHandle* nh, 
-                                  std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler, QWidget *parent) :
+                                   std::map<std::string, ROSEE::JointActuatedType> jointMap, QWidget *parent) :
     QTableWidget(0, 0, parent) {
         
     if (setJointStateSub(nh)) {
@@ -49,23 +49,12 @@ JointStateTable::JointStateTable (ros::NodeHandle* nh,
         horizontalFont.setPointSize(8);
         this->horizontalHeader()->setFont(horizontalFont);
 
-        auto actuatedJointMap = robotDescriptionHandler->getActuatedJointsMap();
-        this->setRowCount(actuatedJointMap.size());
+        this->setRowCount(jointMap.size());
         
         int row = 0;
-        for (auto mapEl : actuatedJointMap) {
+        for (auto mapEl : jointMap) {
             
             QTableWidgetItem* labelWidget = new QTableWidgetItem(QString::fromStdString(mapEl.first));
-            
-            if (mapEl.second == ROSEE::JointActuatedType::ACTUATED) {
-                labelWidget->setBackground(Qt::green);
-                
-            } else if (mapEl.second == ROSEE::JointActuatedType::MIMIC) {
-                labelWidget->setBackground(Qt::yellow);     
-                
-            } else {
-                labelWidget->setBackground(Qt::red);
-            }
 
             setVerticalHeaderItem(row, labelWidget);
             
@@ -104,7 +93,8 @@ void JointStateTable::jointStateClbk(const sensor_msgs::JointStateConstPtr& msg)
         auto mapEl = jointNameRowMap.find(msg->name[i]);
         
         if (mapEl == jointNameRowMap.end()){
-            ROS_WARN_STREAM (__func__ << " '" << msg->name[i] << "' not found in the table of joint states" );
+           // ROS_WARN_STREAM (__func__ << " '" << msg->name[i] << "' not found in the table of joint states" );
+            //now it is normal to go here, because in joinNAmeRowMap only a category of joint is present (mimic active or passive)
         
         } else {
             int row = mapEl->second;

--- a/src/JointStateTable.cpp
+++ b/src/JointStateTable.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rosee_gui/JointStateTable.h>
+
+JointStateTable::JointStateTable (int rows, int columns, QWidget *parent) :
+    QTableWidget(rows, columns, parent) {
+        
+        
+        
+}

--- a/src/JointStateTable.cpp
+++ b/src/JointStateTable.cpp
@@ -22,14 +22,20 @@ JointStateTable::JointStateTable (ros::NodeHandle* nh,
     QTableWidget(0, 0, parent) {
         
     if (setJointStateSub(nh)) {
-        this->setMinimumSize(600,600);
+        //this->setMinimumSize(1,1);
         
         //table not editable
         setEditTriggers(QAbstractItemView::NoEditTriggers);
         //scroll on the horizontal by pixel, otherwise bad visualization occur when scrolling
         setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+        setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
         
+        horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeMode::Stretch);
+        horizontalHeader()->setSectionsMovable(true); 
+        verticalHeader()->setSectionsMovable(true); 
+                
         this->setColumnCount(3); //pos vel effort
+
         QStringList headerLabels;
         headerLabels.append("Position");
         headerLabels.append("Velocity");
@@ -73,7 +79,6 @@ JointStateTable::JointStateTable (ros::NodeHandle* nh,
             jointNameRowMap[mapEl.first] = row;
             row++;
         }
-  
 
     } else {
         //TODO ERROR
@@ -82,7 +87,6 @@ JointStateTable::JointStateTable (ros::NodeHandle* nh,
 }
 
 bool JointStateTable::setJointStateSub(ros::NodeHandle* nh) {
-    
     
     //to get joint state from gazebo, if used
     std::string jsTopic;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -16,18 +16,11 @@
 
 #include <rosee_gui/MainWindow.h>
 
-MainWindow::MainWindow(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
+MainWindow::MainWindow(ros::NodeHandle *nh, QWidget *parent) : QTabWidget(parent) {
 
-    tabWidget = new QTabWidget;
+    addTab(new Window(nh, parent), tr("Action"));
     
-    tabWidget->addTab(new Window(nh, parent), tr("General"));
-    tabWidget->addTab(new Window(nh, parent), tr("tab2"));
-    
-    QVBoxLayout* layout = new QVBoxLayout;
-    layout->addWidget(tabWidget);
-    setLayout(layout);
-
-  
+    addTab(new Window(nh, parent), tr("RobotState"));
 
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -21,7 +21,11 @@ MainWindow::MainWindow(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
     tabWidget = new QTabWidget;
     
     tabWidget->addTab(new Window(nh, parent), tr("General"));
-    tabWidget->addTab(new Window(nh, parent), tr("Culoooo"));
+    tabWidget->addTab(new Window(nh, parent), tr("tab2"));
+    
+    QVBoxLayout* layout = new QVBoxLayout;
+    layout->addWidget(tabWidget);
+    setLayout(layout);
 
   
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -18,9 +18,9 @@
 
 MainWindow::MainWindow(ros::NodeHandle *nh, QWidget *parent) : QTabWidget(parent) {
 
-    addTab(new Window(nh, parent), tr("Action"));
+    addTab(new TabAction(nh, parent), tr("Action"));
     
-    addTab(new Window(nh, parent), tr("RobotState"));
+    addTab(new TabAction(nh, parent), tr("RobotState"));
 
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rosee_gui/MainWindow.h>
+
+MainWindow::MainWindow(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
+
+    tabWidget = new QTabWidget;
+    
+    tabWidget->addTab(new Window(nh, parent), tr("General"));
+    tabWidget->addTab(new Window(nh, parent), tr("Culoooo"));
+
+  
+
+}
+
+

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -17,10 +17,17 @@
 #include <rosee_gui/MainWindow.h>
 
 MainWindow::MainWindow(ros::NodeHandle *nh, QWidget *parent) : QTabWidget(parent) {
-
-    addTab(new TabAction(nh, parent), tr("Action"));
     
-    addTab(new JointMonitorWidget (nh, parent), tr("RobotState"));
+    std::string urdf_file, srdf_file;
+    
+    nh->getParam("robot_description", urdf_file);
+    nh->getParam("robot_description_semantic", srdf_file);
+
+    robotDescriptionHandler = std::make_shared<RobotDescriptionHandler>(urdf_file, srdf_file);
+
+    addTab(new TabAction(nh, robotDescriptionHandler,  parent), tr("Action"));
+    
+    addTab(new JointMonitorWidget (nh, robotDescriptionHandler,  parent), tr("RobotState"));
 
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -20,7 +20,7 @@ MainWindow::MainWindow(ros::NodeHandle *nh, QWidget *parent) : QTabWidget(parent
 
     addTab(new TabAction(nh, parent), tr("Action"));
     
-    addTab(new TabAction(nh, parent), tr("RobotState"));
+    addTab(new JointMonitorWidget (nh, parent), tr("RobotState"));
 
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -27,7 +27,9 @@ MainWindow::MainWindow(ros::NodeHandle *nh, QWidget *parent) : QTabWidget(parent
 
     addTab(new TabAction(nh, robotDescriptionHandler,  parent), tr("Action"));
     
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 9, 0))
     addTab(new JointMonitorWidget (nh, robotDescriptionHandler,  parent), tr("RobotState"));
+#endif
 
 }
 

--- a/src/RobotDescriptionHandler.cpp
+++ b/src/RobotDescriptionHandler.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rosee_gui/RobotDescriptionHandler.h>
+
+RobotDescriptionHandler::RobotDescriptionHandler(std::string urdfFile) {
+    
+    this->_urdfFile = urdfFile;
+    this->_srdfFile = "";
+    
+    if(_urdfFile.empty())
+    {
+        ROS_ERROR_STREAM("urdfFilePath passed is an empty string!");
+        return;
+    }
+    
+    _urdfModel = urdf::parseURDF(_urdfFile);
+}
+
+RobotDescriptionHandler::RobotDescriptionHandler(std::string urdfFile, std::string srdfFile) {
+    
+    this->_urdfFile = urdfFile;
+    this->_srdfFile = srdfFile;
+    
+    if(_urdfFile.empty())
+    {
+        ROS_ERROR_STREAM("urdfFile passed is an empty string!");
+        return;
+    }
+    
+    if(_srdfFile.empty())
+    {
+        ROS_ERROR_STREAM("srdfFile passed is an empty string!");
+        return;
+    }
+    
+    _urdfModel = urdf::parseURDF(_urdfFile);
+    
+    //initString take as 2nd arg the xml content of the file. 
+    //initFile takes instead the flename. We have the file xml content in the param server
+    _srdfModel = boost::make_shared<srdf::Model>();
+    _srdfModel->initString ( *_urdfModel, _srdfFile );
+
+}
+
+srdf::ModelSharedPtr RobotDescriptionHandler::getSrdfModel() {
+    
+    return _srdfModel;
+}
+
+urdf::ModelInterfaceSharedPtr RobotDescriptionHandler::getUrdfModel() {
+    
+    return _urdfModel;
+}
+
+std::string RobotDescriptionHandler::getUrdfFile() {
+    
+    return _urdfFile;
+}
+
+std::string RobotDescriptionHandler::getSrdfFile() {
+    
+    return _srdfFile;
+}
+
+
+
+
+

--- a/src/SingleActionBoxesGroupBox.cpp
+++ b/src/SingleActionBoxesGroupBox.cpp
@@ -242,5 +242,8 @@ void SingleActionBoxesGroupBox::resetAll() {
         box->setEnabled(true);
         box->setChecked(false);
     }
+    
+    actualChecked = 0;
+    send_button->setEnabled(false);
 }
 

--- a/src/SingleActionBoxesGroupBox.cpp
+++ b/src/SingleActionBoxesGroupBox.cpp
@@ -1,8 +1,8 @@
-#include <rosee_gui/ActionBoxesLayout.h>
+#include <rosee_gui/SingleActionBoxesGroupBox.h>
 
-ActionBoxesLayout::ActionBoxesLayout (ros::NodeHandle* nh, 
+SingleActionBoxesGroupBox::SingleActionBoxesGroupBox (ros::NodeHandle* nh, 
                                       rosee_msg::ActionInfo actInfo, QWidget* parent) : 
-                                      ActionLayout(nh, actInfo, parent) {
+                                      SingleActionGroupBox(nh, actInfo, parent) {
 
     if (actInfo.max_selectable > actInfo.selectable_names.size()){
         std::cerr << "[ERROR] max_selectable is " << actInfo.max_selectable << " while you pass only " << actInfo.selectable_names.size()
@@ -46,11 +46,11 @@ ActionBoxesLayout::ActionBoxesLayout (ros::NodeHandle* nh,
 
 }
 
-ActionBoxesLayout::ActionBoxesLayout (ros::NodeHandle* nh, 
+SingleActionBoxesGroupBox::SingleActionBoxesGroupBox (ros::NodeHandle* nh, 
                                       rosee_msg::ActionInfo actInfo,
                                       std::map<std::string, std::vector<std::string>> pairedMap,
                                       QWidget* parent) : 
-                                      ActionLayout(nh, actInfo, parent) {
+                                      SingleActionGroupBox(nh, actInfo, parent) {
 
     if (actInfo.max_selectable != 2) {
         std::cerr << "[ERROR] max_selectable is " << actInfo.max_selectable << 
@@ -104,14 +104,14 @@ ActionBoxesLayout::ActionBoxesLayout (ros::NodeHandle* nh,
 
 }
 
-void ActionBoxesLayout::sendActionRos () {
+void SingleActionBoxesGroupBox::sendActionRos () {
     
     rosee_msg::ROSEECommandGoal goal;
     goal.goal_action.seq = rosMsgSeq++ ;
     goal.goal_action.stamp = ros::Time::now();
     goal.goal_action.percentage = getSpinBoxPercentage();
     goal.goal_action.action_name = actionName;
-    //actionLAyout can be generic or composed, but it do not change what we put in type
+    //singleActionGroupBox can be generic or composed, but it do not change what we put in type
     //because the server will act on them equally
     goal.goal_action.action_type = actionType ;
     goal.goal_action.actionPrimitive_type = actionPrimitiveType ;
@@ -124,12 +124,12 @@ void ActionBoxesLayout::sendActionRos () {
         }
     }
     
-    action_client->sendGoal (goal, boost::bind(&ActionBoxesLayout::doneCallback, this, _1, _2),
-        boost::bind(&ActionBoxesLayout::activeCallback, this), boost::bind(&ActionBoxesLayout::feedbackCallback, this, _1));
+    action_client->sendGoal (goal, boost::bind(&SingleActionBoxesGroupBox::doneCallback, this, _1, _2),
+        boost::bind(&SingleActionBoxesGroupBox::activeCallback, this), boost::bind(&SingleActionBoxesGroupBox::feedbackCallback, this, _1));
 
 }
 
-void ActionBoxesLayout::clickCheckBoxSlot (QAbstractButton* button) {
+void SingleActionBoxesGroupBox::clickCheckBoxSlot (QAbstractButton* button) {
 
     if (button->isChecked()) { //if I clicked to check it...
         actualChecked++;
@@ -159,7 +159,7 @@ void ActionBoxesLayout::clickCheckBoxSlot (QAbstractButton* button) {
 
 }
 
-void ActionBoxesLayout::clickPairCheckBoxSlot (QAbstractButton* button) {
+void SingleActionBoxesGroupBox::clickPairCheckBoxSlot (QAbstractButton* button) {
 
     if (button->isChecked()) { //if I clicked to check it...
         actualChecked++;
@@ -199,7 +199,7 @@ void ActionBoxesLayout::clickPairCheckBoxSlot (QAbstractButton* button) {
     }
 }
 
-void ActionBoxesLayout::disableNotPairedBoxes( std::string boxName ){
+void SingleActionBoxesGroupBox::disableNotPairedBoxes( std::string boxName ){
     
      for (auto box : boxes->buttons()) {
                 
@@ -220,4 +220,12 @@ void ActionBoxesLayout::disableNotPairedBoxes( std::string boxName ){
     }
 }
 
+void SingleActionBoxesGroupBox::resetAll() {
+    
+    SingleActionGroupBox::resetAll();
+    for (auto box : boxes->buttons()) {
+        box->setEnabled(true);
+        box->setChecked(false);
+    }
+}
 

--- a/src/SingleActionBoxesGroupBox.cpp
+++ b/src/SingleActionBoxesGroupBox.cpp
@@ -27,6 +27,7 @@ SingleActionBoxesGroupBox::SingleActionBoxesGroupBox (ros::NodeHandle* nh,
 
     QGridLayout *boxesLayout = new QGridLayout;
     unsigned int buttonId = 0;
+    unsigned int buttonRowColCount = 0; //can be higher that Id because some label may be too long and they do not fit in the second column
     for (auto el : actInfo.selectable_names) {
         QCheckBox* newBox =  new QCheckBox( QString::fromStdString(el));
         newBox->setChecked(false);
@@ -34,8 +35,14 @@ SingleActionBoxesGroupBox::SingleActionBoxesGroupBox (ros::NodeHandle* nh,
         newBox->setToolTip(QString::fromStdString(el));
         boxes->addButton ( newBox, buttonId );
 
-        boxesLayout->addWidget(newBox, buttonId/2, (buttonId%2));
+        //if names is too long and it is in the second column, go to new line
+        if ((buttonRowColCount%2) == 1 && el.size() > 11) {
+            buttonRowColCount++;
+        }
+        
+        boxesLayout->addWidget(newBox, buttonRowColCount/2, (buttonRowColCount%2));
         buttonId++;
+        buttonRowColCount++;
     }
 
     QObject::connect( boxes, SIGNAL (buttonClicked(QAbstractButton*)), this,
@@ -85,15 +92,23 @@ SingleActionBoxesGroupBox::SingleActionBoxesGroupBox (ros::NodeHandle* nh,
 
     QGridLayout *boxesLayout = new QGridLayout;
     unsigned int buttonId = 0;
+    unsigned int buttonRowColCount = 0; //can be higher that Id because some label may be too long and they do not fit in the second column
+
     for (auto el : actInfo.selectable_names) {
         QCheckBox* newBox =  new QCheckBox( QString::fromStdString(el));
         newBox->setChecked(false);
         //tooltip on each checkbox so we can read if the label is cut becasue of no space
         newBox->setToolTip(QString::fromStdString(el));
         boxes->addButton ( newBox, buttonId );
+        
+        //if names is too long and it is in the second column, go to new line
+        if ((buttonRowColCount%2) == 1 && el.size() > 11) {
+            buttonRowColCount++;
+        }
 
-        boxesLayout->addWidget(newBox, buttonId/2, (buttonId%2));
+        boxesLayout->addWidget(newBox, buttonRowColCount/2, (buttonRowColCount%2));
         buttonId++;
+        buttonRowColCount++;
     }
 
     QObject::connect( boxes, SIGNAL (buttonClicked(QAbstractButton*)), this,

--- a/src/SingleActionGroupBox.cpp
+++ b/src/SingleActionGroupBox.cpp
@@ -5,7 +5,7 @@ SingleActionGroupBox::SingleActionGroupBox(ros::NodeHandle* nh, rosee_msg::Actio
     QGroupBox(parent) {
 
     this->setMinimumSize(120,140);
-    this->setMaximumSize(300,400);
+    this->setMaximumSize(400,400);
     this->actionName = actInfo.action_name;
     this->actionType = static_cast<ROSEE::Action::Type> (actInfo.action_type);
     this->rosMsgSeq = 0;
@@ -16,7 +16,7 @@ SingleActionGroupBox::SingleActionGroupBox(ros::NodeHandle* nh, rosee_msg::Actio
 
     QLabel* titleLabel  = new QLabel (QString::fromStdString(actionName));
     titleLabel->setAlignment(Qt::AlignCenter);
-    titleLabel->setStyleSheet("QLabel { font-size :27px }");
+    titleLabel->setStyleSheet("QLabel { font-size :25px }");
     titleLabel->setMaximumHeight(40);
     titleLabel->setToolTip(QString::fromStdString(actionName));
     grid->addWidget(titleLabel, 0, 0);

--- a/src/SingleActionGroupBox.cpp
+++ b/src/SingleActionGroupBox.cpp
@@ -1,7 +1,7 @@
-#include <rosee_gui/ActionLayout.h>
+#include <rosee_gui/SingleActionGroupBox.h>
 
 //TODO add as sub-label the type?
-ActionLayout::ActionLayout(ros::NodeHandle* nh, rosee_msg::ActionInfo actInfo, QWidget* parent) :
+SingleActionGroupBox::SingleActionGroupBox(ros::NodeHandle* nh, rosee_msg::ActionInfo actInfo, QWidget* parent) :
     QGroupBox(parent) {
 
     this->setMinimumSize(300,200);
@@ -50,12 +50,12 @@ ActionLayout::ActionLayout(ros::NodeHandle* nh, rosee_msg::ActionInfo actInfo, Q
     this->setLayout(grid);
 }
 
-double ActionLayout::getSpinBoxPercentage() {
+double SingleActionGroupBox::getSpinBoxPercentage() {
     return (spinBox_percentage->value()/100.0);
 }
 
 
-void ActionLayout::setRosActionClient ( ros::NodeHandle * nh, std::string rosActionName) {
+void SingleActionGroupBox::setRosActionClient ( ros::NodeHandle * nh, std::string rosActionName) {
     
     action_client = 
         std::make_shared <actionlib::SimpleActionClient <rosee_msg::ROSEECommandAction>>
@@ -63,7 +63,7 @@ void ActionLayout::setRosActionClient ( ros::NodeHandle * nh, std::string rosAct
         //false because we handle the thread
 }
 
-void ActionLayout::sendActionRos () {
+void SingleActionGroupBox::sendActionRos () {
 
     rosee_msg::ROSEECommandGoal goal;
     goal.goal_action.seq = rosMsgSeq++ ;
@@ -71,44 +71,48 @@ void ActionLayout::sendActionRos () {
     goal.goal_action.percentage = getSpinBoxPercentage();
     goal.goal_action.action_name = actionName;
     goal.goal_action.action_type = actionType ;
-    //action layout is never for primitives, primitives always use actionBoxesLayout
+    //action layout is never for primitives, primitives always use singleActionBoxesGroupBox
     goal.goal_action.actionPrimitive_type = ROSEE::ActionPrimitive::None ;
     //goal.goal_action.selectable_items left empty 
-    action_client->sendGoal (goal, boost::bind(&ActionLayout::doneCallback, this, _1, _2),
-        boost::bind(&ActionLayout::activeCallback, this), boost::bind(&ActionLayout::feedbackCallback, this, _1)) ;
+    action_client->sendGoal (goal, boost::bind(&SingleActionGroupBox::doneCallback, this, _1, _2),
+        boost::bind(&SingleActionGroupBox::activeCallback, this), boost::bind(&SingleActionGroupBox::feedbackCallback, this, _1)) ;
 
 }
 
-void ActionLayout::doneCallback(const actionlib::SimpleClientGoalState& state,
+void SingleActionGroupBox::doneCallback(const actionlib::SimpleClientGoalState& state,
             const rosee_msg::ROSEECommandResultConstPtr& result) {
     
-    ROS_INFO_STREAM("[ActionLayout " << actionName << "] Finished in state "<<  state.toString().c_str());
+    ROS_INFO_STREAM("[SingleActionGroupBox " << actionName << "] Finished in state "<<  state.toString().c_str());
     progressBar->setValue(100);
     
 }
 
-void ActionLayout::activeCallback() {
-    ROS_INFO_STREAM("[ActionLayout " << actionName << "] Goal just went active");
+void SingleActionGroupBox::activeCallback() {
+    ROS_INFO_STREAM("[SingleActionGroupBox " << actionName << "] Goal just went active");
 }
 
-void ActionLayout::feedbackCallback(
+void SingleActionGroupBox::feedbackCallback(
     const rosee_msg::ROSEECommandFeedbackConstPtr& feedback) {
     
-    ROS_INFO_STREAM("[ActionLayout " << actionName << "] Got Feedback: " << feedback->completation_percentage);
+    ROS_INFO_STREAM("[SingleActionGroupBox " << actionName << "] Got Feedback: " << feedback->completation_percentage);
     progressBar->setValue(feedback->completation_percentage);
 }
 
 
-void ActionLayout::slotSliderReceive(int value){
+void SingleActionGroupBox::slotSliderReceive(int value){
 
     slider_percentage->setValue(value);
 
 }
 
-void ActionLayout::sendBtnClicked() {
+void SingleActionGroupBox::sendBtnClicked() {
 
-    ROS_INFO_STREAM( "[ActionLayout " << actionName << "] The value is " << getSpinBoxPercentage() );
+    ROS_INFO_STREAM( "[SingleActionGroupBox " << actionName << "] The value is " << getSpinBoxPercentage() );
     ROS_INFO_STREAM( "Sending ROS message..." ) ;
     sendActionRos();
 }
 
+void SingleActionGroupBox::resetAll() {
+    progressBar->setValue(0);
+    slider_percentage->setValue(0);
+}

--- a/src/SingleActionGroupBox.cpp
+++ b/src/SingleActionGroupBox.cpp
@@ -4,8 +4,8 @@
 SingleActionGroupBox::SingleActionGroupBox(ros::NodeHandle* nh, rosee_msg::ActionInfo actInfo, QWidget* parent) :
     QGroupBox(parent) {
 
-    this->setMinimumSize(300,200);
-    this->setMaximumHeight(400);
+    this->setMinimumSize(120,140);
+    this->setMaximumSize(300,400);
     this->actionName = actInfo.action_name;
     this->actionType = static_cast<ROSEE::Action::Type> (actInfo.action_type);
     this->rosMsgSeq = 0;
@@ -16,8 +16,9 @@ SingleActionGroupBox::SingleActionGroupBox(ros::NodeHandle* nh, rosee_msg::Actio
 
     QLabel* titleLabel  = new QLabel (QString::fromStdString(actionName));
     titleLabel->setAlignment(Qt::AlignCenter);
-    titleLabel->setStyleSheet("QLabel { font-size :30px }");
+    titleLabel->setStyleSheet("QLabel { font-size :27px }");
     titleLabel->setMaximumHeight(40);
+    titleLabel->setToolTip(QString::fromStdString(actionName));
     grid->addWidget(titleLabel, 0, 0);
     
     progressBar = new QProgressBar();
@@ -44,7 +45,7 @@ SingleActionGroupBox::SingleActionGroupBox(ros::NodeHandle* nh, rosee_msg::Actio
     grid->addLayout(percentageLayout, 3, 0);
 
     send_button = new QPushButton ( "SEND", this );
-    send_button->setGeometry ( 100, 140, 100, 40 );
+    send_button->setMinimumSize(50,20);
     QObject::connect(send_button, SIGNAL ( clicked()), this, SLOT (sendBtnClicked() ) );
     grid->addWidget(send_button, 4, 0);
 

--- a/src/SingleActionGroupBox.cpp
+++ b/src/SingleActionGroupBox.cpp
@@ -10,7 +10,7 @@ SingleActionGroupBox::SingleActionGroupBox(ros::NodeHandle* nh, rosee_msg::Actio
     this->actionType = static_cast<ROSEE::Action::Type> (actInfo.action_type);
     this->rosMsgSeq = 0;
 
-    setRosActionClient(nh, actInfo.ros_action_name);
+    setRosActionClient(nh);
 
     grid = new QGridLayout;
 
@@ -58,11 +58,11 @@ double SingleActionGroupBox::getSpinBoxPercentage() {
 }
 
 
-void SingleActionGroupBox::setRosActionClient ( ros::NodeHandle * nh, std::string rosActionName) {
+void SingleActionGroupBox::setRosActionClient ( ros::NodeHandle * nh) {
     
     action_client = 
         std::make_shared <actionlib::SimpleActionClient <rosee_msg::ROSEECommandAction>>
-        (*nh, rosActionName, false);
+        (*nh, "/ros_end_effector/action_command", false);
         //false because we handle the thread
 }
 

--- a/src/SingleActionGroupBox.cpp
+++ b/src/SingleActionGroupBox.cpp
@@ -5,6 +5,7 @@ SingleActionGroupBox::SingleActionGroupBox(ros::NodeHandle* nh, rosee_msg::Actio
     QGroupBox(parent) {
 
     this->setMinimumSize(300,200);
+    this->setMaximumHeight(400);
     this->actionName = actInfo.action_name;
     this->actionType = static_cast<ROSEE::Action::Type> (actInfo.action_type);
     this->rosMsgSeq = 0;
@@ -16,6 +17,7 @@ SingleActionGroupBox::SingleActionGroupBox(ros::NodeHandle* nh, rosee_msg::Actio
     QLabel* titleLabel  = new QLabel (QString::fromStdString(actionName));
     titleLabel->setAlignment(Qt::AlignCenter);
     titleLabel->setStyleSheet("QLabel { font-size :30px }");
+    titleLabel->setMaximumHeight(40);
     grid->addWidget(titleLabel, 0, 0);
     
     progressBar = new QProgressBar();

--- a/src/SingleActionTimedGroupBox.cpp
+++ b/src/SingleActionTimedGroupBox.cpp
@@ -41,13 +41,13 @@ SingleActionTimedGroupBox::SingleActionTimedGroupBox (ros::NodeHandle* nh, rosee
     setRosActionClient(nh, actInfo.ros_action_name);
                                           
     this->setMinimumSize(120*nInner,100);
-    this->setMaximumSize(300*nInner,400);
+    this->setMaximumSize(400*nInner,400);
 
     grid = new QGridLayout;
     
     windowLabel = new QLabel (QString::fromStdString(actInfo.action_name));
     windowLabel->setAlignment(Qt::AlignCenter);
-    windowLabel->setStyleSheet("QLabel { font-size : 27px }");
+    windowLabel->setStyleSheet("QLabel { font-size : 25px }");
     grid->addWidget(windowLabel, 0, 0, 1, nInner);
     
     send_button = new QPushButton ( "SEND", this );

--- a/src/SingleActionTimedGroupBox.cpp
+++ b/src/SingleActionTimedGroupBox.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <rosee_gui/ActionTimedLayout.h>
+#include <rosee_gui/SingleActionTimedGroupBox.h>
 
-ActionTimedLayout::ActionTimedLayout (ros::NodeHandle* nh, rosee_msg::ActionInfo actInfo,
+SingleActionTimedGroupBox::SingleActionTimedGroupBox (ros::NodeHandle* nh, rosee_msg::ActionInfo actInfo,
                                       QWidget* parent) : QGroupBox(parent) {
     
     if (actInfo.inner_actions.size() == 0) {
@@ -28,7 +28,7 @@ ActionTimedLayout::ActionTimedLayout (ros::NodeHandle* nh, rosee_msg::ActionInfo
     
     if (nInner != actInfo.before_margins.size() ||
         nInner != actInfo.after_margins.size() ) {
-        ROS_ERROR_STREAM("[ERROR ActionTimedLayout costructor] different size of innerNames and innerTimeMargins: " 
+        ROS_ERROR_STREAM("[ERROR SingleActionTimedGroupBox costructor] different size of innerNames and innerTimeMargins: " 
         << nInner << " and " << actInfo.before_margins.size() <<
         "(before marg), and " << actInfo.after_margins.size()
         << "(after marg)");
@@ -70,15 +70,15 @@ ActionTimedLayout::ActionTimedLayout (ros::NodeHandle* nh, rosee_msg::ActionInfo
     this->setLayout(grid);
 }
 
-void ActionTimedLayout::sendBtnClicked() {
+void SingleActionTimedGroupBox::sendBtnClicked() {
 
-    ROS_INFO_STREAM( "[ActionTimedLayout " << actionName << "] Sending ROS message..." ) ;
+    ROS_INFO_STREAM( "[SingleActionTimedGroupBox " << actionName << "] Sending ROS message..." ) ;
     sendActionRos();
-    ROS_INFO_STREAM( "[ActionTimedLayout " << actionName << "] ... sent" ) ;
+    ROS_INFO_STREAM( "[SingleActionTimedGroupBox " << actionName << "] ... sent" ) ;
 
 }
 
-void ActionTimedLayout::setRosActionClient(ros::NodeHandle* nh, std::string rosActionName) {
+void SingleActionTimedGroupBox::setRosActionClient(ros::NodeHandle* nh, std::string rosActionName) {
     
     action_client = 
         std::make_shared <actionlib::SimpleActionClient <rosee_msg::ROSEECommandAction>>
@@ -86,7 +86,7 @@ void ActionTimedLayout::setRosActionClient(ros::NodeHandle* nh, std::string rosA
         //false because we handle the thread
 }
 
-void ActionTimedLayout::sendActionRos () {
+void SingleActionTimedGroupBox::sendActionRos () {
 
     rosee_msg::ROSEECommandGoal goal;
     goal.goal_action.seq = rosMsgSeq++ ;
@@ -97,29 +97,29 @@ void ActionTimedLayout::sendActionRos () {
     goal.goal_action.actionPrimitive_type = ROSEE::ActionPrimitive::Type::None ;
     //goal.goal_action.selectable_items left empty 
 
-    action_client->sendGoal (goal, boost::bind(&ActionTimedLayout::doneCallback, this, _1, _2),
-        boost::bind(&ActionTimedLayout::activeCallback, this), boost::bind(&ActionTimedLayout::feedbackCallback, this, _1)) ;
+    action_client->sendGoal (goal, boost::bind(&SingleActionTimedGroupBox::doneCallback, this, _1, _2),
+        boost::bind(&SingleActionTimedGroupBox::activeCallback, this), boost::bind(&SingleActionTimedGroupBox::feedbackCallback, this, _1)) ;
 
 }
 
-void ActionTimedLayout::doneCallback(const actionlib::SimpleClientGoalState& state,
+void SingleActionTimedGroupBox::doneCallback(const actionlib::SimpleClientGoalState& state,
             const rosee_msg::ROSEECommandResultConstPtr& result) {
     
-    ROS_INFO_STREAM("[ActionTimedLayout " << actionName << "] Finished in state "<<  state.toString().c_str());
+    ROS_INFO_STREAM("[SingleActionTimedGroupBox " << actionName << "] Finished in state "<<  state.toString().c_str());
     //progressBar->setValue(100);
     
 }
 
-void ActionTimedLayout::activeCallback() {
+void SingleActionTimedGroupBox::activeCallback() {
     
-    ROS_INFO_STREAM("[ActionTimedLayout " << actionName << "] Goal just went active");
+    ROS_INFO_STREAM("[SingleActionTimedGroupBox " << actionName << "] Goal just went active");
     
 }
 
-void ActionTimedLayout::feedbackCallback(
+void SingleActionTimedGroupBox::feedbackCallback(
     const rosee_msg::ROSEECommandFeedbackConstPtr& feedback) {
     
-    ROS_INFO_STREAM("[ActionTimedLayout " << actionName << "] Got Feedback: " <<
+    ROS_INFO_STREAM("[SingleActionTimedGroupBox " << actionName << "] Got Feedback: " <<
         feedback->action_name_current << " , "  << feedback->completation_percentage);    
 
     ActionTimedElement* el = this->findChild <ActionTimedElement*> (
@@ -141,3 +141,12 @@ void ActionTimedLayout::feedbackCallback(
    
 }
 
+//TODO or it is better to store the child and not look for them each time?
+void SingleActionTimedGroupBox::resetAll() {
+    
+    QList<ActionTimedElement *> childElements = this->findChildren<ActionTimedElement *>();
+    
+    for (auto it : childElements) {
+        it->resetAll();
+    }
+}

--- a/src/SingleActionTimedGroupBox.cpp
+++ b/src/SingleActionTimedGroupBox.cpp
@@ -38,7 +38,7 @@ SingleActionTimedGroupBox::SingleActionTimedGroupBox (ros::NodeHandle* nh, rosee
     this->actionName = actInfo.action_name;
     this->rosMsgSeq = 0;
 
-    setRosActionClient(nh, actInfo.ros_action_name);
+    setRosActionClient(nh);
                                           
     this->setMinimumSize(120*nInner,100);
     this->setMaximumSize(400*nInner,400);
@@ -79,11 +79,11 @@ void SingleActionTimedGroupBox::sendBtnClicked() {
 
 }
 
-void SingleActionTimedGroupBox::setRosActionClient(ros::NodeHandle* nh, std::string rosActionName) {
+void SingleActionTimedGroupBox::setRosActionClient(ros::NodeHandle* nh) {
     
     action_client = 
         std::make_shared <actionlib::SimpleActionClient <rosee_msg::ROSEECommandAction>>
-        (*nh, rosActionName, false);
+        (*nh, "/ros_end_effector/action_command", false);
         //false because we handle the thread
 }
 

--- a/src/SingleActionTimedGroupBox.cpp
+++ b/src/SingleActionTimedGroupBox.cpp
@@ -40,13 +40,14 @@ SingleActionTimedGroupBox::SingleActionTimedGroupBox (ros::NodeHandle* nh, rosee
 
     setRosActionClient(nh, actInfo.ros_action_name);
                                           
-    this->setMinimumSize(600,200);
+    this->setMinimumSize(120*nInner,100);
+    this->setMaximumSize(300*nInner,400);
 
     grid = new QGridLayout;
     
     windowLabel = new QLabel (QString::fromStdString(actInfo.action_name));
     windowLabel->setAlignment(Qt::AlignCenter);
-    windowLabel->setStyleSheet("QLabel { font-size : 40px }");
+    windowLabel->setStyleSheet("QLabel { font-size : 27px }");
     grid->addWidget(windowLabel, 0, 0, 1, nInner);
     
     send_button = new QPushButton ( "SEND", this );

--- a/src/TabAction.cpp
+++ b/src/TabAction.cpp
@@ -1,34 +1,42 @@
 #include <rosee_gui/TabAction.h>
 
-TabAction::TabAction(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
+TabAction::TabAction(ros::NodeHandle *nh, 
+                     std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler,
+                     QWidget *parent) : QWidget(parent) {
 
     this->nh = nh;
 
-    createActionGroupBox();
-    createJointStateContainer();
+    // createActionGroupBox();
+    //createJointStateContainer();
+    
+    //the group box where the singleActionGroupBox will be set.
+    //This groupbox will be added with addWidget in TabAction costructor
+    containerActionGroupBox = new ContainerActionGroupBox(nh, parent);
+    
+    jointStateContainer = new JointStateContainer(nh, robotDescriptionHandler, parent);
+    
     
     QGridLayout *windowGrid = new QGridLayout;
     windowGrid->addWidget(containerActionGroupBox, 0, 0);
     windowGrid->addLayout(jointStateContainer, 0, 1);
     setLayout(windowGrid);
-    
   
-
-}
-
-
-void TabAction::createJointStateContainer() {
-    
-    jointStateContainer = new JointStateContainer(nh);
-    
 }
 
 void TabAction::createActionGroupBox() {
     
     //the group box where the singleActionGroupBox will be set.
     //This groupbox will be added with addWidget in TabAction costructor
-    containerActionGroupBox = new ContainerActionGroupBox(nh, this);
+    //containerActionGroupBox = new ContainerActionGroupBox(nh, this);
     
 }
+
+void TabAction::createJointStateContainer() {
+    
+    //jointStateContainer = new JointStateContainer(nh);
+    
+}
+
+
 
 

--- a/src/TabAction.cpp
+++ b/src/TabAction.cpp
@@ -1,6 +1,6 @@
-#include <rosee_gui/Window.h>
+#include <rosee_gui/TabAction.h>
 
-Window::Window(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
+TabAction::TabAction(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
 
     this->nh = nh;
 
@@ -17,16 +17,16 @@ Window::Window(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
 }
 
 
-void Window::createJointStateContainer() {
+void TabAction::createJointStateContainer() {
     
     jointStateContainer = new JointStateContainer(nh);
     
 }
 
-void Window::createActionGroupBox() {
+void TabAction::createActionGroupBox() {
     
     //the group box where the singleActionGroupBox will be set.
-    //This groupbox will be added with addWidget in Window costructor
+    //This groupbox will be added with addWidget in TabAction costructor
     containerActionGroupBox = new ContainerActionGroupBox(nh, this);
     
 }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -3,161 +3,32 @@
 Window::Window(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
 
     this->nh = nh;
-    
-    // get (wait) for info from unviersalroseeExecutor about all the action parsed by it
-    getInfoServices();
-    
+
     createActionGroupBox();
-    createJointStateTable();
+    createJointStateContainer();
     
     QGridLayout *windowGrid = new QGridLayout;
-    windowGrid->addWidget(actionGroupBox, 0, 0);
-    windowGrid->addWidget(jointStateTable, 0, 1);
+    windowGrid->addWidget(containerActionGroupBox, 0, 0);
+    windowGrid->addLayout(jointStateContainer, 0, 1);
     setLayout(windowGrid);
     
   
 
 }
 
-void Window::createJointStateTable() {
+
+void Window::createJointStateContainer() {
     
-    jointStateTable = new JointStateTable(0,0, this);
-    jointStateTable->setRowCount(1);
-    jointStateTable->setColumnCount(1);
-    
-    QStringList headerLabels;
-    headerLabels.append("asd");
-    jointStateTable->setHorizontalHeaderLabels(headerLabels);
-    
-    jointStateTable->setRowCount(2);
-    jointStateTable->setColumnCount(2);
-    
+    jointStateContainer = new JointStateContainer(nh);
     
 }
 
 void Window::createActionGroupBox() {
     
-    //the group box where the actionLayout will be set.
+    //the group box where the singleActionGroupBox will be set.
     //This groupbox will be added with addWidget in Window costructor
-    actionGroupBox = new QGroupBox;
-    
-    // the layout that contain all the actions
-    actionContainerLayout = new QGridLayout();
-
-    int rowCol = 0;
-    
-    for (auto actInfo: actionInfoVect) {
-            
-        switch (actInfo.action_type) {
-        
-        case ROSEE::Action::Type::Primitive :
-        {
-            if (actInfo.max_selectable == 2) {
-                // get (wait) for service that provide info of which element can be paired
-                // so in the gui we disable the not pairable checkboxes if one is checked
-                std::map<std::string, std::vector<std::string>> pairedElementMap = 
-                    getPairMap(actInfo.action_name, actInfo.selectable_names);
-                
-                ActionBoxesLayout* actionBoxesLayout;
-                if (pairedElementMap.size() != 0) {
-                    actionBoxesLayout = 
-                    new ActionBoxesLayout(nh, actInfo, pairedElementMap, this) ;
-                    
-                } else {
-                    //version without disabling the not pairable checkboxes
-                    actionBoxesLayout = 
-                    new ActionBoxesLayout(nh, actInfo, this) ; 
-                    
-                }
-                actionContainerLayout->addWidget (actionBoxesLayout, rowCol/4, rowCol%4);
-                
-            } else {
-                ActionBoxesLayout* actionBoxesLayout;
-                actionBoxesLayout = 
-                    new ActionBoxesLayout(nh, actInfo, this) ; 
-                actionContainerLayout->addWidget (actionBoxesLayout, rowCol/4, rowCol%4);
-            }
-
-            break;
-        }
-        case ROSEE::Action::Type::Generic : // same thing as composed
-        case ROSEE::Action::Type::Composed :
-        {
-            ActionLayout* actionLayout = new ActionLayout(nh, actInfo, this);
-            actionContainerLayout->addWidget (actionLayout, rowCol/4, rowCol%4);
-            break;
-        }
-        case ROSEE::Action::Type::Timed : 
-        {
-            ActionTimedLayout* timed = new ActionTimedLayout(nh, actInfo, this);
-            actionContainerLayout->addWidget(timed, rowCol/4, rowCol%4, 1, actInfo.inner_actions.size());
-
-            break;
-        }
-        case ROSEE::Action::Type::None :
-        {
-            
-            ROS_ERROR_STREAM ("GUI ERROR, type NONE received for action " << actInfo.action_name);
-            throw "";
-            break;
-        }
-        default : {
-            ROS_ERROR_STREAM ("GUI ERROR, not recognized type " << actInfo.action_type
-            << " received for action " << actInfo.action_name);
-            throw "";
-        }
-        } 
-        
-        rowCol++;
-    }
-
-    actionGroupBox->setLayout(actionContainerLayout);
-    
-}
-
-void Window::getInfoServices() {
-    
-    ros::service::waitForService("ros_end_effector/ActionsInfo"); //blocking infinite wait, it also print
-    
-    rosee_msg::ActionsInfo actionsInfo;
-
-    if (ros::service::call ("ros_end_effector/ActionsInfo", actionsInfo)) {
-        actionInfoVect = actionsInfo.response.actionsInfo;
-    } else {
-        ROS_ERROR_STREAM (" ros::service::call FAILED " );
-    }
+    containerActionGroupBox = new ContainerActionGroupBox(nh, this);
     
 }
 
 
-std::map < std::string, std::vector<std::string> > Window::getPairMap( 
-    std::string action_name, std::vector<std::string> elements) {
-    
-    std::map<std::string, std::vector<std::string>> pairedElementMap;
-    
-    ROS_INFO_STREAM ("waiting for ros_end_effector/SelectablePairInfo service for 5 seconds...");
-    if (! ros::service::waitForService("ros_end_effector/SelectablePairInfo", 5000)) {
-        ROS_WARN_STREAM ("ros_end_effector/SelectablePairInfo not found");
-        return std::map < std::string, std::vector<std::string> >();
-    }
-    ROS_INFO_STREAM ("... service found, I will call it");
-
-    rosee_msg::SelectablePairInfo pairInfo;
-    pairInfo.request.action_name = action_name;
-
-    for (auto elementName : elements) {
-        pairInfo.request.element_name = elementName;
-        if (ros::service::call("ros_end_effector/SelectablePairInfo", pairInfo)) {
-            
-            pairedElementMap.insert(std::make_pair(elementName, pairInfo.response.pair_elements) );
-            
-        } else {
-            ROS_ERROR_STREAM ("ros_end_effector/SelectablePairInfo call failed with " << 
-                pairInfo.request.action_name << ", " << pairInfo.request.element_name <<
-                " as request");
-            return std::map < std::string, std::vector<std::string> >();
-
-        }
-    }
-    return pairedElementMap;
-}

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -7,8 +7,43 @@ Window::Window(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
     // get (wait) for info from unviersalroseeExecutor about all the action parsed by it
     getInfoServices();
     
-    QGridLayout *grid = new QGridLayout;
+    createActionGroupBox();
+    createJointStateTable();
     
+    QGridLayout *windowGrid = new QGridLayout;
+    windowGrid->addWidget(actionGroupBox, 0, 0);
+    windowGrid->addWidget(jointStateTable, 0, 1);
+    setLayout(windowGrid);
+    
+  
+
+}
+
+void Window::createJointStateTable() {
+    
+    jointStateTable = new JointStateTable(0,0, this);
+    jointStateTable->setRowCount(1);
+    jointStateTable->setColumnCount(1);
+    
+    QStringList headerLabels;
+    headerLabels.append("asd");
+    jointStateTable->setHorizontalHeaderLabels(headerLabels);
+    
+    jointStateTable->setRowCount(2);
+    jointStateTable->setColumnCount(2);
+    
+    
+}
+
+void Window::createActionGroupBox() {
+    
+    //the group box where the actionLayout will be set.
+    //This groupbox will be added with addWidget in Window costructor
+    actionGroupBox = new QGroupBox;
+    
+    // the layout that contain all the actions
+    actionContainerLayout = new QGridLayout();
+
     int rowCol = 0;
     
     for (auto actInfo: actionInfoVect) {
@@ -34,13 +69,13 @@ Window::Window(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
                     new ActionBoxesLayout(nh, actInfo, this) ; 
                     
                 }
-                grid->addWidget (actionBoxesLayout, rowCol/4, rowCol%4);
+                actionContainerLayout->addWidget (actionBoxesLayout, rowCol/4, rowCol%4);
                 
             } else {
                 ActionBoxesLayout* actionBoxesLayout;
                 actionBoxesLayout = 
                     new ActionBoxesLayout(nh, actInfo, this) ; 
-                grid->addWidget (actionBoxesLayout, rowCol/4, rowCol%4);
+                actionContainerLayout->addWidget (actionBoxesLayout, rowCol/4, rowCol%4);
             }
 
             break;
@@ -49,13 +84,13 @@ Window::Window(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
         case ROSEE::Action::Type::Composed :
         {
             ActionLayout* actionLayout = new ActionLayout(nh, actInfo, this);
-            grid->addWidget (actionLayout, rowCol/4, rowCol%4);
+            actionContainerLayout->addWidget (actionLayout, rowCol/4, rowCol%4);
             break;
         }
         case ROSEE::Action::Type::Timed : 
         {
             ActionTimedLayout* timed = new ActionTimedLayout(nh, actInfo, this);
-            grid->addWidget(timed, rowCol/4, rowCol%4, 1, actInfo.inner_actions.size());
+            actionContainerLayout->addWidget(timed, rowCol/4, rowCol%4, 1, actInfo.inner_actions.size());
 
             break;
         }
@@ -76,8 +111,8 @@ Window::Window(ros::NodeHandle *nh, QWidget *parent) : QWidget(parent) {
         rowCol++;
     }
 
-    setLayout(grid);
-
+    actionGroupBox->setLayout(actionContainerLayout);
+    
 }
 
 void Window::getInfoServices() {

--- a/src/chart/CMakeLists.txt
+++ b/src/chart/CMakeLists.txt
@@ -4,6 +4,7 @@ add_compile_options(-std=c++14)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
+set(QT5_PATH "/usr/share/qt5-15/5.15.0/gcc_64")
 set(QT5_PATH "" CACHE PATH "Path to QT > 5.9")
 set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT5_PATH}")
 

--- a/src/chart/CMakeLists.txt
+++ b/src/chart/CMakeLists.txt
@@ -4,14 +4,10 @@ add_compile_options(-std=c++14)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-set(QT5_PATH "/usr/share/qt5-15/5.15.0/gcc_64")
-set(QT5_PATH "" CACHE PATH "Path to QT > 5.9")
-set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT5_PATH}")
 
-
-find_package(Qt5UiTools 5.12 REQUIRED)
-find_package(Qt5Widgets 5.12 REQUIRED)
-find_package(Qt5Charts 5.12 REQUIRED)
+find_package(Qt5UiTools 5.9 REQUIRED)
+find_package(Qt5Widgets 5.9 REQUIRED)
+find_package(Qt5Charts 5.9 REQUIRED)
 
 add_library(chart_widget STATIC chart.cpp chart_resources.qrc)
 target_link_libraries(chart_widget PUBLIC Qt5::Widgets Qt5::Charts Qt5::UiTools)

--- a/src/chart/CMakeLists.txt
+++ b/src/chart/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+add_compile_options(-std=c++14)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(QT5_PATH "" CACHE PATH "Path to QT > 5.9")
+set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${QT5_PATH}")
+
+
+find_package(Qt5UiTools 5.12 REQUIRED)
+find_package(Qt5Widgets 5.12 REQUIRED)
+find_package(Qt5Charts 5.12 REQUIRED)
+
+add_library(chart_widget STATIC chart.cpp chart_resources.qrc)
+target_link_libraries(chart_widget PUBLIC Qt5::Widgets Qt5::Charts Qt5::UiTools)

--- a/src/chart/chart.cpp
+++ b/src/chart/chart.cpp
@@ -46,6 +46,9 @@ ChartWidget::ChartWidget(QWidget * parent):
     /* Chart */
     _chart = new QChart;
     _chart->legend()->setAlignment(Qt::AlignRight);
+    
+    //show name in tooltip when it is too long to be visualized
+    _chart->legend()->setShowToolTips(true);
 
     /* Axes */
     _axis_x = new QValueAxis;
@@ -136,7 +139,6 @@ void ChartWidget::addSeries(QString name)
     series->attachAxis(_axis_x);
     series->attachAxis(_axis_y);
 
-
     _series[name] = series;
 
     auto markers = _chart->legend()->markers(series);
@@ -148,7 +150,6 @@ void ChartWidget::addSeries(QString name)
 
         connect(m, &QLegendMarker::clicked,
                 this, &ChartWidget::legend_marker_clicked);
-
     }
 
     reset_view();

--- a/src/chart/chart.cpp
+++ b/src/chart/chart.cpp
@@ -49,6 +49,8 @@ ChartWidget::ChartWidget(QWidget * parent):
     
     //show name in tooltip when it is too long to be visualized
     _chart->legend()->setShowToolTips(true);
+    _chart->legend()->setFont(QFont("Ubuntu", 9));
+    _chart->legend()->setMaximumWidth(290);
 
     /* Axes */
     _axis_x = new QValueAxis;

--- a/src/chart/chart.cpp
+++ b/src/chart/chart.cpp
@@ -1,0 +1,469 @@
+#include "chart.h"
+
+#include <QGraphicsLayout>
+#include <QVBoxLayout>
+#include <QTimer>
+#include <QLegendMarker>
+#include <QtUiTools/QUiLoader>
+#include <QCheckBox>
+#include <QPushButton>
+
+#include <QApplication>
+
+void qrc_init()
+{
+    Q_INIT_RESOURCE(chart_resources);
+}
+
+namespace  {
+
+
+QWidget * LoadUiFile(QWidget * parent, QString name)
+{
+    qrc_init();
+
+    QUiLoader loader;
+
+    QFile file(":/" + name + ".ui");
+    file.open(QFile::ReadOnly);
+
+    QWidget *formWidget = loader.load(&file, parent);
+    file.close();
+
+    return formWidget;
+
+}
+
+}
+
+ChartWidget::ChartWidget(QWidget * parent):
+    _auto_y_range(true),
+    _x_range(10.0),
+    _autoscroll(true),
+    _t(.0),
+    _empty_chart(true)
+{
+    /* Chart */
+    _chart = new QChart;
+    _chart->legend()->setAlignment(Qt::AlignRight);
+
+    /* Axes */
+    _axis_x = new QValueAxis;
+    _axis_y = new QValueAxis;
+    _axis_x->setRange(-_x_range, 0.0);
+    _axis_y->setRange(-1., 1.);
+
+    _chart->addAxis(_axis_x, Qt::AlignBottom);
+    _chart->addAxis(_axis_y, Qt::AlignLeft);
+
+    // Formatting
+    _chart->setBackgroundVisible(false);
+    _chart->setMargins(QMargins(0,0,0,0));
+    _chart->layout()->setContentsMargins(0,0,0,0);
+    _chart->setPlotAreaBackgroundBrush(QBrush(Qt::black));
+    _chart->setPlotAreaBackgroundVisible(true);
+    _chart_view = new CustomChartView(_chart);
+    _chart_view->setRubberBand(QChartView::RectangleRubberBand);
+    _chart_view->setRenderHint(QPainter::Antialiasing, true);
+
+
+    auto hlayout = new QVBoxLayout;
+    setLayout(hlayout);
+    hlayout->addWidget(_chart_view);
+
+    _scroll_timer = new QTimer;
+    _timer_period_ms = 40.;
+    _scroll_timer->setInterval(int(_timer_period_ms + 0.5));
+
+    auto right_panel = LoadUiFile(this, "right_panel");
+    hlayout->addWidget(right_panel);
+
+    connect(_scroll_timer, &QTimer::timeout,
+            this, &ChartWidget::on_timer_event);
+
+    connect(_chart_view, &CustomChartView::resetViewEvent,
+            this, &ChartWidget::reset_view);
+
+    connect(_chart_view, &CustomChartView::customViewEvent,
+            [this]()
+    {
+        _auto_y_range = false;
+    });
+
+    auto autoscroll = right_panel->findChild<QCheckBox*>("autoscroll");
+    autoscroll->setCheckState(Qt::CheckState::Checked);
+    connect(autoscroll, &QCheckBox::toggled,
+            [this](bool toggled)
+    {
+        _autoscroll = toggled;
+    });
+
+    auto removeall = right_panel->findChild<QPushButton*>("removeAll");
+    connect(removeall, &QPushButton::released,
+            [this]()
+    {
+        for(auto p : _series)
+        {
+            removeSeries(p.first);
+        }
+    });
+
+    auto resetview = right_panel->findChild<QPushButton*>("resetView");
+    connect(resetview, &QPushButton::released,
+            this, &ChartWidget::reset_view);
+
+    _fps_label = right_panel->findChild<QLabel*>("fpsLabel");
+
+    _scroll_timer->start();
+}
+
+void ChartWidget::setDefaultRange(double range)
+{
+    _x_range = range;
+}
+
+void ChartWidget::addSeries(QString name)
+{
+    if(_series.count(name) > 0)
+    {
+        return;
+    }
+
+    auto series = new QLineSeries;
+    series->setName(name);
+    series->setUseOpenGL();
+    _chart->addSeries(series);
+    series->attachAxis(_axis_x);
+    series->attachAxis(_axis_y);
+
+
+    _series[name] = series;
+
+    auto markers = _chart->legend()->markers(series);
+
+    for(auto m : markers)
+    {
+        connect(m, &QLegendMarker::hovered,
+                this, &ChartWidget::legend_marker_hovered);
+
+        connect(m, &QLegendMarker::clicked,
+                this, &ChartWidget::legend_marker_clicked);
+
+    }
+
+    reset_view();
+
+}
+
+void ChartWidget::removeSeries(QString name)
+{
+    {
+        auto it = _series.find(name);
+
+        if(it == _series.end())
+        {
+            return;
+        }
+
+        _chart->removeSeries(it->second);
+        _series.erase(it);
+    }
+
+    {
+        auto it = _point_to_add.find(name);
+
+        if(it == _point_to_add.end())
+        {
+            return;
+        }
+
+        _point_to_add.erase(it);
+    }
+
+
+    if(_series.empty())
+    {
+        _empty_chart = true;
+    }
+
+}
+
+void ChartWidget::addPoint(QString name,
+                           double t,
+                           double val)
+{
+    auto it = _series.find(name);
+
+    if(it == _series.end())
+    {
+        return;
+    }
+
+    _point_to_add[name] = QPointF(t, val);
+
+    //    it->second->append(t, val);
+    _t = t;
+
+    if(_auto_y_range)
+    {
+        if(val + 0.1*std::fabs(val) > _axis_y->max())
+        {
+            _axis_y->setMax(val + 0.1*std::fabs(val));
+        }
+
+        if(val - 0.1*std::fabs(val) < _axis_y->min())
+        {
+            _axis_y->setMin(val - 0.1*std::fabs(val));
+        }
+    }
+
+    if(_empty_chart)
+    {
+        _empty_chart = false;
+        reset_view();
+    }
+}
+
+void ChartWidget::on_timer_event()
+{
+    auto tic = std::chrono::high_resolution_clock::now();
+
+    for(const auto& p : _point_to_add)
+    {
+        _series.at(p.first)->append(p.second);
+    }
+
+    _point_to_add.clear();
+
+    if(_autoscroll)
+    {
+        auto range = _axis_x->max() - _axis_x->min();
+        auto dx = _chart->plotArea().width() / range * _timer_period_ms * 0.001;
+        _chart->scroll(dx, 0);
+    }
+
+    auto toc = std::chrono::high_resolution_clock::now();
+
+    std::chrono::duration<double> dt = toc - tic;
+    int fps = 1/dt.count();
+
+    _fps_label->setText(QString("%1 FPS").arg(fps));
+
+
+}
+
+void ChartWidget::legend_marker_hovered(bool hover)
+{
+    auto* marker = qobject_cast<QLegendMarker*>(sender());
+    Q_ASSERT(marker);
+
+    QFont font = marker->font();
+    font.setBold(hover);
+    marker->setFont(font);
+
+    if (marker->series()->type() == QAbstractSeries::SeriesTypeLine)
+    {
+        auto series = qobject_cast<QLineSeries*>(marker->series());
+        auto pen = series->pen();
+        pen.setWidth(hover ? (pen.width() * 3) : (pen.width() / 3));
+        series->setPen(pen);
+    }
+
+}
+
+void ChartWidget::legend_marker_clicked()
+{
+    auto* marker = qobject_cast<QLegendMarker*>(sender());
+    Q_ASSERT(marker);
+
+    // Toggle visibility of series
+    setSeriesVisible(marker->series(), !marker->series()->isVisible());
+}
+
+void ChartWidget::reset_view()
+{
+
+    _auto_y_range = true;
+    _axis_x->setRange(_t - _x_range, _t);
+
+    double y_min =  1e10;
+    double y_max = -1e10;
+
+    bool point_found = false;
+
+    for(auto p : _series)
+    {
+        auto s = p.second;
+        auto points = s->pointsVector();
+        if(!points.empty()) point_found = true;
+
+        auto comp = [](const QPointF& a, const QPointF& b)
+        {
+            return a.y() < b.y();
+        };
+
+        auto it_max = std::max_element(points.begin(), points.end(),
+                                       comp);
+        auto it_min = std::min_element(points.begin(), points.end(),
+                                       comp);
+
+        y_min = std::min(y_min, it_min->y());
+        y_max = std::max(y_max, it_max->y());
+
+    }
+
+    auto range = y_max - y_min;
+    range = std::max(range, 1.0);
+    y_min = y_min - 0.1*(range);
+    y_max = y_max + 0.1*(range);
+
+    if(point_found)
+    {
+        _axis_y->setRange(y_min, y_max);
+    }
+
+}
+
+void ChartWidget::setSeriesVisible(QAbstractSeries *series, bool visible)
+{
+    series->setVisible(visible);
+    for (QLegendMarker *marker : _chart->legend()->markers(series)) {
+        // Turn legend marker back to visible, since hiding series also hides the marker
+        // and we don't want it to happen now.
+        marker->setVisible(true);
+
+        // Dim the marker, if series is not visible
+        qreal alpha = visible ? 1.0 : 0.5;
+        QColor color;
+        QBrush brush = marker->labelBrush();
+        color = brush.color();
+        color.setAlphaF(alpha);
+        brush.setColor(color);
+        marker->setLabelBrush(brush);
+
+        brush = marker->brush();
+        color = brush.color();
+        color.setAlphaF(alpha);
+        brush.setColor(color);
+        marker->setBrush(brush);
+
+        QPen pen = marker->pen();
+        color = pen.color();
+        color.setAlphaF(alpha);
+        pen.setColor(color);
+        marker->setPen(pen);
+    }
+
+    for (QAbstractAxis *axis : _chart->axes(Qt::Vertical)) {
+        bool hideAxis = true;
+        for (QAbstractSeries *series : _chart->series()) {
+            for (QAbstractAxis *attachedAxis : series->attachedAxes()) {
+                if (series->isVisible() && attachedAxis == axis) {
+                    hideAxis = false;
+                    break;
+                }
+            }
+            if (!hideAxis)
+                break;
+        }
+        axis->setVisible(!hideAxis);
+    }
+}
+
+
+CustomChartView::CustomChartView(QChart* chart, QWidget* parent):
+    QChartView (chart, parent)
+{
+    setDragMode(QGraphicsView::NoDrag);
+    setMouseTracking(true);
+
+}
+
+void CustomChartView::mousePressEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::MiddleButton)
+    {
+        QApplication::setOverrideCursor(QCursor(Qt::SizeAllCursor));
+        event->accept();
+    }
+
+    _lastMousePos = event->pos();
+    _firstMousePos = _lastMousePos;
+
+    emit customViewEvent();
+
+    QChartView::mousePressEvent(event);
+}
+
+void CustomChartView::mouseReleaseEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::RightButton)
+    {
+        event->accept();
+        return;
+    }
+
+    QChartView::mouseReleaseEvent(event);
+}
+
+void CustomChartView::mouseMoveEvent(QMouseEvent* event)
+{
+    // pan the chart with a middle mouse drag
+    if (event->buttons() & Qt::MiddleButton)
+    {
+        auto dPos = event->pos() - _lastMousePos;
+        chart()->scroll(-dPos.x(), dPos.y());
+
+        _lastMousePos = event->pos();
+        event->accept();
+
+        QApplication::restoreOverrideCursor();
+    }
+
+    if(event->buttons() & Qt::RightButton)
+    {
+        auto dPos = event->pos() - _lastMousePos;
+        _lastMousePos = event->pos();
+
+        double factor_x = 1 - 10.*dPos.x()/chart()->plotArea().width();
+        double factor_y = 1 - 10.*dPos.y()/chart()->plotArea().height();
+
+        factor_x = std::min(10., std::max(0.1, factor_x));
+        factor_y = std::min(10., std::max(0.1, factor_y));
+
+        QRectF r = QRectF(chart()->plotArea().left(),
+                          chart()->plotArea().top(),
+                          chart()->plotArea().width()/factor_x,
+                          chart()->plotArea().height()/factor_y);
+
+        chart()->zoomIn(r);
+
+        QPointF mousePos = mapFromGlobal(QCursor::pos());
+
+        QPointF delta = chart()->plotArea().center() - mousePos;
+        chart()->scroll(-dPos.x(), dPos.y());
+    }
+
+
+    QChartView::mouseMoveEvent(event);
+}
+
+void CustomChartView::wheelEvent(QWheelEvent* event)
+{
+    qreal factor;
+    if ( event->delta() > 0 )
+        factor = 1.33;
+    else
+        factor = 0.75;
+
+    QRectF r = QRectF(chart()->plotArea().left(),
+                      chart()->plotArea().top(),
+                      chart()->plotArea().width()/factor,
+                      chart()->plotArea().height()/factor);
+
+    QPointF mousePos = mapFromGlobal(QCursor::pos());
+    r.moveCenter(mousePos);
+    chart()->zoomIn(r);
+    QPointF delta = chart()->plotArea().center() - mousePos;
+    chart()->scroll(delta.x(), -delta.y());
+}

--- a/src/chart/chart.h
+++ b/src/chart/chart.h
@@ -1,0 +1,82 @@
+#ifndef CHART_H
+#define CHART_H
+
+#include <QWidget>
+//TODO fix this
+//#include <QChart>
+//#include <QChartView>
+//#include <QLineSeries>
+//#include <QValueAxis>
+#include "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64/include/QtCharts/qchart.h"
+#include "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64/include/QtCharts/qchartview.h"
+#include "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64/include/QtCharts/qlineseries.h"
+#include "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64/include/QtCharts/qvalueaxis.h"
+
+#include <QLabel>
+
+
+QT_CHARTS_USE_NAMESPACE
+
+class CustomChartView : public QChartView
+{
+
+    Q_OBJECT
+
+public:
+
+    CustomChartView(QChart* chart, QWidget *parent = nullptr);
+
+signals:
+
+    void resetViewEvent();
+    void customViewEvent();
+
+protected:
+
+    virtual void mousePressEvent(QMouseEvent *event) override;
+    virtual void mouseReleaseEvent(QMouseEvent *event) override;
+    virtual void mouseMoveEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+
+private:
+
+    QPointF _lastMousePos, _firstMousePos;
+};
+
+class ChartWidget : public QWidget
+{
+
+public:
+
+    ChartWidget(QWidget * parent = nullptr);
+    void setDefaultRange(double range);
+    void addSeries(QString name);
+    void removeSeries(QString name);
+    void addPoint(QString name, double t, double x);
+
+private:
+
+    void on_timer_event();
+    void legend_marker_hovered(bool hover);
+    void legend_marker_clicked();
+    void reset_view();
+
+    void setSeriesVisible(QAbstractSeries *series, bool visible);
+
+    std::map<QString, QLineSeries *> _series;
+    std::map<QString, QPointF> _point_to_add;
+    QChart * _chart;
+    CustomChartView * _chart_view;
+    QValueAxis * _axis_x, * _axis_y;
+    bool _auto_y_range;
+    bool _autoscroll;
+    double _x_range;
+    double _t;
+    bool _empty_chart;
+
+    QTimer * _scroll_timer;
+    double _timer_period_ms;
+    QLabel * _fps_label;
+};
+
+#endif // CHART_H

--- a/src/chart/chart.h
+++ b/src/chart/chart.h
@@ -2,18 +2,11 @@
 #define CHART_H
 
 #include <QWidget>
-//TODO fix this
-//#include <QChart>
-//#include <QChartView>
-//#include <QLineSeries>
-//#include <QValueAxis>
-#include "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64/include/QtCharts/qchart.h"
-#include "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64/include/QtCharts/qchartview.h"
-#include "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64/include/QtCharts/qlineseries.h"
-#include "/usr/lib/x86_64-linux-gnu/Qt5.12.8/5.12.8/gcc_64/include/QtCharts/qvalueaxis.h"
-
+#include <QtCharts/QChart>
+#include <QtCharts/QChartView>
+#include <QtCharts/QLineSeries>
+#include <QtCharts/QValueAxis>
 #include <QLabel>
-
 
 QT_CHARTS_USE_NAMESPACE
 

--- a/src/chart/chart.h
+++ b/src/chart/chart.h
@@ -7,6 +7,7 @@
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QValueAxis>
 #include <QLabel>
+#include <chrono>
 
 QT_CHARTS_USE_NAMESPACE
 

--- a/src/chart/chart_resources.qrc
+++ b/src/chart/chart_resources.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource>
+    <file>right_panel.ui</file>
+</qresource>
+</RCC>

--- a/src/chart/right_panel.ui
+++ b/src/chart/right_panel.ui
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>290</width>
+    <height>43</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QPushButton" name="resetView">
+     <property name="text">
+      <string>Reset view</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="removeAll">
+     <property name="text">
+      <string>Remove all</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="autoscroll">
+     <property name="text">
+      <string>Autoscroll</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="fpsLabel">
+     <property name="text">
+      <string>24 FPS</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/joint_state_gui/CMakeLists.txt
+++ b/src/joint_state_gui/CMakeLists.txt
@@ -1,0 +1,31 @@
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt5UiTools ${MINIMUM_QT_VERSION} REQUIRED)
+find_package(Qt5Widgets ${MINIMUM_QT_VERSION} REQUIRED)
+find_package(Qt5Quick ${MINIMUM_QT_VERSION} REQUIRED)
+find_package(catkin REQUIRED COMPONENTS roscpp urdf)
+
+include_directories(${catkin_INCLUDE_DIRS})
+
+add_library(joint_bar_ui STATIC
+    bar_plot_widget.cpp
+    joint_bar_widget.cpp
+    joint_state_widget.cpp
+    joint_monitor_widget.cpp
+    circle_widget.cpp
+    ui_resources.qrc)
+
+target_link_libraries(joint_bar_ui chart_widget
+    Qt5::Widgets Qt5::UiTools ${catkin_LIBRARIES} yaml-cpp)
+
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Mark executables and/or libraries for installation
+#install(TARGETS joint_state_gui
+#    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+#    )

--- a/src/joint_state_gui/CMakeLists.txt
+++ b/src/joint_state_gui/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(joint_bar_ui STATIC
     ui_resources.qrc)
 
 target_link_libraries(joint_bar_ui chart_widget
-    Qt5::Widgets Qt5::UiTools ${catkin_LIBRARIES} yaml-cpp)
+    Qt5::Widgets Qt5::UiTools ${catkin_LIBRARIES} yaml-cpp ${PROJECT_NAME}_RobotDescriptionHandler)
 
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)

--- a/src/joint_state_gui/bar_plot_widget.cpp
+++ b/src/joint_state_gui/bar_plot_widget.cpp
@@ -1,0 +1,108 @@
+#include "bar_plot_widget.h"
+#include "joint_bar_widget.h"
+
+#include <QUiLoader>
+#include <QFile>
+#include <QVBoxLayout>
+#include <QComboBox>
+
+void bar_plot_widget_qrc_init()
+{
+    Q_INIT_RESOURCE(ui_resources);
+}
+
+namespace  {
+
+
+QWidget * LoadUiFile(QWidget * parent)
+{
+    bar_plot_widget_qrc_init();
+
+    QUiLoader loader;
+
+    QFile file(":/bar_plot_widget.ui");
+    file.open(QFile::ReadOnly);
+
+    QWidget *formWidget = loader.load(&file, parent);
+    file.close();
+
+    return formWidget;
+
+
+}
+
+}
+
+BarPlotWidget::BarPlotWidget(std::vector<std::string> jnames, QWidget *parent) : QWidget(parent)
+{
+    /* Create GUI layout */
+    auto * ui = ::LoadUiFile(this);
+    auto * layout = new QVBoxLayout;
+    layout->addWidget(ui);
+    setLayout(layout);
+
+    auto bars_layout_left = findChild<QVBoxLayout *>("BarsLayoutLeft");
+    auto bars_layout_right = findChild<QVBoxLayout *>("BarsLayoutRight");
+
+    for(int i = 0; i < jnames.size(); i++)
+    {
+
+        auto wid = new JointBarWidget(QString::fromStdString(jnames[i]),
+                                      this);
+
+        if(i < jnames.size() / 2 || jnames.size() < 8)
+        {
+            bars_layout_left->addWidget(wid);
+        }
+        else
+        {
+            bars_layout_right->addWidget(wid);
+        }
+
+        wid_map[jnames[i]] = wid;
+
+    }
+
+
+    _fieldtype_combobox = findChild<QComboBox *>("SelectFieldComboBox");
+    _fieldtype_combobox->addItem("Joint Position");
+    _fieldtype_combobox->addItem("Joint Velocity");
+    _fieldtype_combobox->addItem("Joint Effort");
+
+
+}
+
+void BarPlotWidget::setOnJointClicked(std::function<void (std::string)> f)
+{
+    for(auto pair : wid_map)
+    {
+//        pair.second->setOnBarDoubleClick(std::bind(f, pair.first));
+    }
+}
+
+std::string BarPlotWidget::getFieldType() const
+{
+    return _fieldtype_combobox->currentText().toStdString();
+}
+
+std::string BarPlotWidget::getFieldShortType() const
+{
+    auto type = getFieldType();
+
+    std::map<std::string, std::string> type_to_short_type;
+    type_to_short_type["Link position" ] = "link_pos";
+    type_to_short_type["Motor position"] = "motor_pos";
+    type_to_short_type["Link velocity" ] = "link_vel";
+    type_to_short_type["Motor velocity"] = "motor_vel";
+    type_to_short_type["Torque"        ] = "torque";
+    type_to_short_type["Stiffness"     ] = "k";
+    type_to_short_type["Damping"       ] = "d";
+    type_to_short_type["Current"       ] = "current";
+
+    if(type_to_short_type.count(type) > 0)
+    {
+        return type_to_short_type.at(type);
+    }
+
+    return "";
+}

--- a/src/joint_state_gui/bar_plot_widget.cpp
+++ b/src/joint_state_gui/bar_plot_widget.cpp
@@ -90,14 +90,9 @@ std::string BarPlotWidget::getFieldShortType() const
     auto type = getFieldType();
 
     std::map<std::string, std::string> type_to_short_type;
-    type_to_short_type["Link position" ] = "link_pos";
-    type_to_short_type["Motor position"] = "motor_pos";
-    type_to_short_type["Link velocity" ] = "link_vel";
-    type_to_short_type["Motor velocity"] = "motor_vel";
-    type_to_short_type["Torque"        ] = "torque";
-    type_to_short_type["Stiffness"     ] = "k";
-    type_to_short_type["Damping"       ] = "d";
-    type_to_short_type["Current"       ] = "current";
+    type_to_short_type["Joint Position" ] = "joint_pos";
+    type_to_short_type["Joint Velocity"] = "joint_vel";
+    type_to_short_type["Joint Effort" ] = "joint_eff";
 
     if(type_to_short_type.count(type) > 0)
     {

--- a/src/joint_state_gui/bar_plot_widget.cpp
+++ b/src/joint_state_gui/bar_plot_widget.cpp
@@ -50,7 +50,7 @@ BarPlotWidget::BarPlotWidget(std::vector<std::string> jnames, QWidget *parent) :
         auto wid = new JointBarWidget(QString::fromStdString(jnames[i]),
                                       this);
 
-        if(i < jnames.size() / 2 || jnames.size() < 8)
+        if(i < jnames.size() / 2 || jnames.size() < 6)
         {
             bars_layout_left->addWidget(wid);
         }

--- a/src/joint_state_gui/bar_plot_widget.h
+++ b/src/joint_state_gui/bar_plot_widget.h
@@ -1,0 +1,31 @@
+#ifndef BAR_PLOT_WIDGET_H
+#define BAR_PLOT_WIDGET_H
+
+#include <QWidget>
+#include <QComboBox>
+#include <unordered_map>
+
+#include "joint_bar_widget.h"
+
+class BarPlotWidget : public QWidget
+{
+
+public:
+
+    explicit BarPlotWidget(std::vector<std::string> jnames, QWidget * parent = nullptr);
+
+    void setOnJointClicked(std::function<void(std::string)> f);
+
+    std::string getFieldType() const;
+    std::string getFieldShortType() const;
+
+    std::unordered_map<std::string, JointBarWidget *> wid_map;
+
+private:
+
+    QComboBox * _fieldtype_combobox;
+
+
+};
+
+#endif // BAR_PLOT_WIDGET_H

--- a/src/joint_state_gui/bar_plot_widget.ui
+++ b/src/joint_state_gui/bar_plot_widget.ui
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BarPlotWidget</class>
+ <widget class="QWidget" name="BarPlotWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Field name</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QComboBox" name="SelectFieldComboBox"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="10,4,10">
+     <item>
+      <layout class="QVBoxLayout" name="BarsLayoutLeft">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+      </layout>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="BarsLayoutRight">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/joint_state_gui/circle_widget.cpp
+++ b/src/joint_state_gui/circle_widget.cpp
@@ -1,0 +1,18 @@
+#include "circle_widget.h"
+#include <QPainter>
+
+//CircleWidget::CircleWidget(QWidget *parent) : QWidget(parent)
+//{
+
+//}
+
+//void CircleWidget::paintEvent(QPaintEvent * ev)
+//{
+//    QPainter painter( this );
+
+//    painter.setRenderHint( QPainter::Antialiasing );
+
+//    painter.setPen(QColor(255, 0, 0));
+//    painter.setBrush(QColor(255, 0, 0));
+//    painter.drawEllipse(0, 0, 20, 20);
+//}

--- a/src/joint_state_gui/circle_widget.h
+++ b/src/joint_state_gui/circle_widget.h
@@ -1,0 +1,39 @@
+#ifndef CIRCLE_WIDGET_H
+#define CIRCLE_WIDGET_H
+
+#include <QApplication>
+#include <QMouseEvent>
+#include <QWidget>
+#include <QPainter>
+
+class CircleWidget : public QWidget
+{
+public:
+   CircleWidget(int number) : _number(number), _fill(false) {/*empty*/}
+
+   virtual void paintEvent(QPaintEvent * e)
+   {
+      e->accept();
+
+      QPainter p(this);
+
+      QRect r = rect();
+      p.setPen(Qt::black);
+      if (_fill) p.setBrush(Qt::green);
+      p.drawEllipse(r);
+
+      p.drawText(r, Qt::AlignCenter, QString("%1").arg(_number));
+   }
+
+   virtual void mousePressEvent(QMouseEvent * e)
+   {
+      _fill = !_fill;
+      update();  // this will induce another call to paintEvent() ASAP
+      e->accept();
+   }
+
+private:
+   const int _number;
+   bool _fill;
+};
+#endif // CIRCLE_WIDGET_H

--- a/src/joint_state_gui/joint_bar_widget.cpp
+++ b/src/joint_state_gui/joint_bar_widget.cpp
@@ -69,13 +69,16 @@ void JointBarWidget::setRange(double min, double max)
 void JointBarWidget::setValue(double x)
 {
     _bar->setValue(x);
-    _bar->setFormat(QString("%1").arg(x, 5,'f',1));
+    //%1 is the placeholder for the arg.
+    //arg values: first is value printed (x), 5 is a sort of padding with respect to 
+    //the 5 arg ('' by default). 'f' is format, 1 is precision
+    _bar->setFormat(QString("%1").arg(x, 5,'f',2));
 }
 
 void JointBarWidget::setValue(double xbar, double xtext)
 {
     _bar->setValue(xbar);
-    _bar->setFormat(QString("%1").arg(xtext, 5,'f',1));
+    _bar->setFormat(QString("%1").arg(xtext, 5,'f',2));
 }
 
 void JointBarWidget::setStatus(QString status)

--- a/src/joint_state_gui/joint_bar_widget.cpp
+++ b/src/joint_state_gui/joint_bar_widget.cpp
@@ -1,8 +1,6 @@
 #include "joint_bar_widget.h"
 #include "circle_widget.h"
 
-#include <iostream>
-
 #include <QUiLoader>
 #include <QFile>
 #include <QVBoxLayout>

--- a/src/joint_state_gui/joint_bar_widget.cpp
+++ b/src/joint_state_gui/joint_bar_widget.cpp
@@ -55,6 +55,10 @@ JointBarWidget::JointBarWidget(const QString& jname, QWidget *parent) :
     _jname = findChild<QLabel *>("JointLabel");
     _jname->installEventFilter(this);
     _jname->setText(jname);
+    
+    //so we can modify the label with (active, passive, mimic) and still return
+    //the right joint name
+    originalJname = jname;
 
     _on_double_click = [](){};
 }
@@ -131,7 +135,8 @@ void JointBarWidget::setInactive()
 
 QString JointBarWidget::getJointName() const
 {
-    return _jname->text();
+    //return _jname->text();
+    return originalJname;
 }
 
 void JointBarWidget::setColor(Qt::GlobalColor color)

--- a/src/joint_state_gui/joint_bar_widget.cpp
+++ b/src/joint_state_gui/joint_bar_widget.cpp
@@ -1,0 +1,216 @@
+#include "joint_bar_widget.h"
+#include "circle_widget.h"
+
+#include <iostream>
+
+#include <QUiLoader>
+#include <QFile>
+#include <QVBoxLayout>
+#include <QProgressBar>
+#include <QEvent>
+#include <QMouseEvent>
+#include <QFrame>
+
+void joint_bar_widget_qrc_init()
+{
+    Q_INIT_RESOURCE(ui_resources);
+}
+
+namespace  {
+
+
+
+QWidget * LoadUiFile(QWidget * parent)
+{
+
+    joint_bar_widget_qrc_init();
+
+    QUiLoader loader;
+
+    QFile file(":/joint_bar_widget.ui");
+    file.open(QFile::ReadOnly);
+
+    QWidget *formWidget = loader.load(&file, parent);
+    file.close();
+
+    return formWidget;
+
+
+}
+
+}
+
+JointBarWidget::JointBarWidget(const QString& jname, QWidget *parent) :
+    QWidget(parent),
+    _blinker(this),
+    _state(0)
+{
+    /* Create GUI layout */
+    auto * ui = ::LoadUiFile(this);
+    auto * layout = new QVBoxLayout;
+    layout->addWidget(ui);
+    layout->setMargin(3);
+    setLayout(layout);
+
+    _bar = findChild<QProgressBar *>("ValueBar");
+    _bar->installEventFilter(this);
+    _jname = findChild<QLabel *>("JointLabel");
+    _jname->installEventFilter(this);
+    _jname->setText(jname);
+
+    _on_double_click = [](){};
+}
+
+void JointBarWidget::setRange(double min, double max)
+{
+    _bar->setRange(min, max);
+}
+
+void JointBarWidget::setValue(double x)
+{
+    _bar->setValue(x);
+    _bar->setFormat(QString("%1").arg(x, 5,'f',1));
+}
+
+void JointBarWidget::setValue(double xbar, double xtext)
+{
+    _bar->setValue(xbar);
+    _bar->setFormat(QString("%1").arg(xtext, 5,'f',1));
+}
+
+void JointBarWidget::setStatus(QString status)
+{
+//    _status->setText(status);
+}
+
+void JointBarWidget::setSafe(bool force)
+{
+    if(_blinker.blinking()) return;
+
+    if(_state != 0)
+    {
+        printf("Started blinker..\n");
+        _blinker.blink(10);
+    }
+
+    _state = 0;
+
+    setColor(Qt::green);
+}
+
+void JointBarWidget::setDanger(bool force)
+{
+    if(_state == 0)
+    {
+        _blinker.stop();
+    }
+
+    setColor(Qt::red);
+
+    _state = 1;
+
+}
+
+void JointBarWidget::setActive()
+{
+    _jname->setStyleSheet("font-weight: bold");
+}
+
+void JointBarWidget::setInactive()
+{
+    _jname->setStyleSheet("font-weight: normal");
+}
+
+QString JointBarWidget::getJointName() const
+{
+    return _jname->text();
+}
+
+void JointBarWidget::setColor(Qt::GlobalColor color)
+{
+    auto frame = findChild<QFrame *>("StatusFrame");
+    QPalette pal;
+    pal.setColor(QPalette::Background, color);
+    frame->setAutoFillBackground(true);
+    frame->setPalette(pal);
+}
+
+bool JointBarWidget::eventFilter(QObject * obj, QEvent * event)
+{
+    if (event->type() == QEvent::MouseButtonDblClick)
+    {
+        QMouseEvent * mouse_event = static_cast<QMouseEvent *>(event);
+        if(mouse_event->button() == Qt::MouseButton::LeftButton)
+        {
+            emit doubleLeftClicked();
+        }
+        if(mouse_event->button() == Qt::MouseButton::RightButton)
+        {
+            emit doubleRightClicked();
+        }
+
+        return true;
+    }
+    else
+    {
+        // standard event processing
+        return QObject::eventFilter(obj, event);
+    }
+}
+
+Blinker::Blinker(JointBarWidget * parent):
+    _blinks(0),
+    _state(0),
+    _parent(parent)
+{
+    _timer.setInterval(500);
+    _timer.setSingleShot(false);
+
+    connect(&_timer, &QTimer::timeout,
+            this, &Blinker::on_timeout);
+
+}
+
+void Blinker::stop()
+{
+    _blinks = 0;
+    _timer.stop();
+}
+
+void Blinker::on_timeout()
+{
+    if(_blinks == 0)
+    {
+        _parent->setColor(Qt::green);
+        _timer.stop();
+    }
+
+    printf("Blinking..\n");
+
+    if(_state == 0)
+    {
+        _parent->setColor(Qt::green);
+        _state = 1;
+    }
+    else {
+        _parent->setColor(Qt::red);
+        _state = 0;
+    }
+
+    _blinks--;
+
+}
+
+void Blinker::blink(int nblinks)
+{
+    if(_blinks > 0) return;
+
+    _blinks = nblinks;
+    _state = 1;
+    _timer.start();
+}
+
+bool Blinker::blinking() const
+{
+    return _blinks > 0;
+}

--- a/src/joint_state_gui/joint_bar_widget.cpp
+++ b/src/joint_state_gui/joint_bar_widget.cpp
@@ -116,12 +116,19 @@ void JointBarWidget::setDanger(bool force)
 
 void JointBarWidget::setActive()
 {
-    _jname->setStyleSheet("font-weight: bold");
+    //not with stylesheet so we do not overwite highlight colors
+    //_jname->setStyleSheet("font-weight: bold");
+    auto font = _jname->font();
+    font.setBold(true);
+    _jname->setFont(font);
 }
 
 void JointBarWidget::setInactive()
 {
-    _jname->setStyleSheet("font-weight: normal");
+    //_jname->setStyleSheet("font-weight: normal");
+    auto font = _jname->font();
+    font.setBold(false);
+    _jname->setFont(font);
 }
 
 QString JointBarWidget::getJointName() const

--- a/src/joint_state_gui/joint_bar_widget.h
+++ b/src/joint_state_gui/joint_bar_widget.h
@@ -7,6 +7,9 @@
 #include <QLabel>
 #include <QTimer>
 
+#include <iostream>
+
+
 class JointBarWidget;
 
 class Blinker : public QObject

--- a/src/joint_state_gui/joint_bar_widget.h
+++ b/src/joint_state_gui/joint_bar_widget.h
@@ -78,6 +78,8 @@ private:
     QProgressBar * _bar;
     QLabel * _jname;
     QLabel * _status;
+    
+    QString originalJname;
 
     Blinker _blinker;
     int _state;

--- a/src/joint_state_gui/joint_bar_widget.h
+++ b/src/joint_state_gui/joint_bar_widget.h
@@ -1,0 +1,86 @@
+#ifndef JOINT_BAR_WIDGET_H
+#define JOINT_BAR_WIDGET_H
+
+#include <QWidget>
+#include <functional>
+#include <QProgressBar>
+#include <QLabel>
+#include <QTimer>
+
+class JointBarWidget;
+
+class Blinker : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    Blinker(JointBarWidget * parent);
+
+    void stop();
+
+    void blink(int nblinks);
+
+    bool blinking() const;
+
+
+public slots :
+
+    void on_timeout();
+
+private:
+
+
+    QTimer _timer;
+
+    int _blinks;
+    int _state;
+    JointBarWidget * _parent;
+};
+
+class JointBarWidget : public QWidget
+{
+
+    Q_OBJECT
+
+public:
+
+    friend class Blinker;
+
+    explicit JointBarWidget(const QString& jname, QWidget * parent = nullptr);
+
+    void setRange(double min, double max);
+    void setValue(double x);
+    void setValue(double xbar, double xtext);
+    void setStatus(QString status);
+    void setSafe(bool force = false);
+    void setDanger(bool force = false);
+    void setActive();
+    void setInactive();
+    QString getJointName() const;
+
+signals:
+
+    void doubleLeftClicked();
+    void doubleRightClicked();
+
+private:
+
+    void setColor(Qt::GlobalColor color);
+
+    bool eventFilter(QObject * obj, QEvent * ev) override;
+
+    std::function<void(void)> _on_double_click;
+
+    QProgressBar * _bar;
+    QLabel * _jname;
+    QLabel * _status;
+
+    Blinker _blinker;
+    int _state;
+
+
+
+};
+
+#endif // JOINT_BAR_WIDGET_H

--- a/src/joint_state_gui/joint_bar_widget.ui
+++ b/src/joint_state_gui/joint_bar_widget.ui
@@ -46,6 +46,14 @@
        <height>0</height>
       </size>
      </property>
+     <property name="font">
+      <font>
+       <pointsize>10</pointsize>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
      <property name="text">
       <string>knee_pitch_1</string>
      </property>

--- a/src/joint_state_gui/joint_bar_widget.ui
+++ b/src/joint_state_gui/joint_bar_widget.ui
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>JointBarWidget</class>
+ <widget class="QWidget" name="JointBarWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>381</width>
+    <height>35</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>300</width>
+    <height>20</height>
+   </size>
+  </property>
+  <property name="baseSize">
+   <size>
+    <width>0</width>
+    <height>20</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QLabel" name="JointLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>knee_pitch_1</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="ValueBar">
+     <property name="minimum">
+      <number>25</number>
+     </property>
+     <property name="value">
+      <number>50</number>
+     </property>
+     <property name="textVisible">
+      <bool>true</bool>
+     </property>
+     <property name="invertedAppearance">
+      <bool>false</bool>
+     </property>
+     <property name="format">
+      <string notr="true">JointName - 68 °C</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="StatusFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -270,7 +270,7 @@ void JointMonitorWidget::on_jstate_recv(const sensor_msgs::JointStateConstPtr& m
         //     wid->setDanger();
         //}
 
-
+            
         if(barplot_wid->getFieldType() == "Joint Effort")
         {
             auto wid = barplot_wid->wid_map.at(msg->name[i]);
@@ -283,10 +283,13 @@ void JointMonitorWidget::on_jstate_recv(const sensor_msgs::JointStateConstPtr& m
         else if(barplot_wid->getFieldType() == "Joint Position")
         {
             auto wid = barplot_wid->wid_map.at(msg->name[i]);
-            wid->setValue(msg->position[i]);
+            //set range want only integer... so I multiply by 100 everything,
+            // but the text will be written correct.
+            // if we getValue, we will need to divide it by 100
+            wid->setValue(msg->position[i]*100, msg->position[i]);
             double qmin = _urdf->getJoint(msg->name[i])->limits->lower;
             double qmax = _urdf->getJoint(msg->name[i])->limits->upper;
-            wid->setRange(qmin, qmax);
+            wid->setRange(qmin*100, qmax*100);
         }
         
         else if(barplot_wid->getFieldType() == "Joint Velocity")

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -1,0 +1,302 @@
+#include "joint_monitor_widget.h"
+#include "bar_plot_widget.h"
+#include <QHBoxLayout>
+
+#include <urdf_parser/urdf_parser.h>
+
+struct BIT_FAULT {
+
+    // bits 0..3
+    uint16_t  m3_rxpdo_pos_ref:1;   // ?
+    uint16_t  m3_rxpdo_vel_ref:1;   // ?
+    uint16_t  m3_rxpdo_tor_ref:1;   // ?
+    uint16_t  m3_fault_hardware:1;  // ! +
+    // bits 4..7
+    uint16_t  m3_params_out_of_range:1;         // !
+    uint16_t  m3_torque_array_not_loaded:1;     // !
+    uint16_t  m3_torque_read_error:1;           // ? ++
+    uint16_t  m3_spare:1;
+    // bits 8, 9
+    /* 20 BAD consecutive sensor readings give error
+     * each GOOD or almost good ( green/orange) reading decrement error counter
+     * each other conditions on reading increment error counter
+     */
+    uint16_t  m3_link_enc_error:1;  // ? +
+    /* 20 consecutive sensor readings give error
+     * see m3_link_enc_error
+     */
+    uint16_t  m3_defl_enc_error:1;  // ? ++
+    /*
+    The warning bit is set when the temperature is over 60 and released when decrease under 55 degrees.
+    The warning bit is only checked before starting the controller, if is set the controller is not allowed to start.
+    If set during run no action is provided, is only a signal that the system is getting warm.
+    The error bit is set when the temperature is over 70 and released when decrease under 65 degrees.
+    The error bit is always checked, if a temperature error is triggered the system doesn’t start the controller
+    and if is running it stop the controller.
+    For the motor temperature is the same behavior (the warning and error temperature bit are shared)
+    but the temperature limits are different (80 for warning and 90 for error with 5 degrees histeresys)
+    */
+    // bits 10, 11
+    uint16_t  m3_temperature_warning:1; // ?
+    uint16_t  m3_temperature_error:1;   // ? +
+    // bits 12..15
+    /* 200 consecutive sensor readings give error
+     * see m3_link_enc_error
+     */
+    uint16_t  c28_motor_enc_error:1;    // ? +
+    uint16_t  c28_v_batt_read_fault:1;  // ?
+    uint16_t  c28_enter_sand_box:1; // ?
+    uint16_t  c28_spare_1:1;
+
+
+    std::ostream& dump ( std::ostream& os, const std::string delim ) const {
+
+        if(m3_rxpdo_pos_ref)    { os << "m3_rxpdo_pos_ref" << delim; }
+        if(m3_rxpdo_vel_ref)    { os << "m3_rxpdo_vel_ref" << delim; }
+        if(m3_rxpdo_tor_ref)    { os << "m3_rxpdo_tor_ref" << delim; }
+        if(m3_fault_hardware)   { os << "m3_fault_hardware" << delim; }
+
+        if(m3_params_out_of_range)      { os << "m3_params_out_of_range" << delim; }
+        if(m3_torque_array_not_loaded)  { os << "m3_torque_array_not_loaded" << delim; }
+        if(m3_torque_read_error) { os << "m3_torque_read_out_of_range" << delim; }
+
+        if(m3_link_enc_error)       { os << "m3_link_enc_error" << delim; }
+        if(m3_defl_enc_error)       { os << "m3_defl_enc_error" << delim; }
+        if(m3_temperature_warning)  { os << "m3_temperature_warning" << delim; }
+        if(m3_temperature_error)    { os << "m3_temperature_error" << delim; }
+
+        if(c28_motor_enc_error)     { os << "c28_motor_enc_error" << delim; }
+        if(c28_v_batt_read_fault)   { os << "c28_v_batt_read_fault" << delim; }
+        if(c28_enter_sand_box)      { os << "c28_enter_sand_box" << delim; }
+
+        return os;
+    }
+
+    void fprint ( FILE *fp ) {
+        std::ostringstream oss;
+        dump(oss,"\t");
+        fprintf ( fp, "%s", oss.str().c_str() );
+    }
+    int sprint ( char *buff, size_t size ) {
+        std::ostringstream oss;
+        dump(oss,"\t");
+        return snprintf ( buff, size, "%s", oss.str().c_str() );
+    }
+
+};
+
+union centAC_fault_t{
+    uint16_t all;
+    BIT_FAULT bit;
+};
+
+JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh, QWidget *parent) :
+    QWidget(parent),
+    _valid_msg_recv(false),
+    _widget_started(false)
+{
+    
+    std::string jsTopic;
+    nh->param<std::string>("/rosee/joint_states_topic", jsTopic, "/ros_end_effector/joint_states");
+    _jstate_sub = nh->subscribe(jsTopic, 10, &JointMonitorWidget::on_jstate_recv, this);
+    ROS_INFO_STREAM ( "[2nd Tab] Getting joint pos from '" << jsTopic << "'" );
+
+
+    std::string urdf_str;
+    nh->getParam("robot_description", urdf_str);
+
+    if(urdf_str.empty())
+    {
+        throw std::runtime_error("Unable to read robot_description from parameter server");
+    }
+
+    _urdf = urdf::parseURDF(urdf_str);
+
+    while(!_valid_msg_recv)
+    {
+        ros::spinOnce();
+        ROS_INFO_STREAM_ONCE("Waiting for joint states valid message...");
+        usleep(1000);
+    }
+    
+
+    std::string jidmap_str = nh->param<std::string>("robot_description_joint_id_map", "");
+    if(!jidmap_str.empty())
+    {
+        try
+        {
+            auto jidmap_yaml = YAML::Load(jidmap_str);
+            for(auto p: jidmap_yaml["joint_map"])
+            {
+                _jidmap[p.second.as<std::string>()] = p.first.as<int>();
+            }
+        }
+        catch(std::exception& e)
+        {
+            fprintf(stderr, "Unable to get joint IDs: %s \n", e.what());
+        }
+    }
+
+
+    jstate_wid = new JointStateWidget(this);
+    jstate_wid->setJointName(QString::fromStdString(_jnames[0]), 0);
+
+    barplot_wid = new BarPlotWidget(_jnames, this);
+
+    auto on_joint_clicked = [this](std::string jname)
+    {
+        auto wid = barplot_wid->wid_map.at(jstate_wid->getJointName().toStdString());
+        wid->setInactive();
+        int jid = _jidmap.count(jname) > 0 ? _jidmap.at(jname) : 0;
+        jstate_wid->setJointName(QString::fromStdString(jname), jid);
+        wid = barplot_wid->wid_map.at(jname);
+        wid->setActive();
+    };
+
+    on_joint_clicked(_jnames[0]);
+
+    for(auto p: barplot_wid->wid_map)
+    {
+        connect(p.second, &JointBarWidget::doubleLeftClicked,
+                [p, on_joint_clicked](){ on_joint_clicked(p.first); });
+
+        connect(p.second, &JointBarWidget::doubleRightClicked,
+                [p, this]()
+        {
+
+            _chart->addSeries(p.second->getJointName() +
+                              "/" +
+                              QString::fromStdString(barplot_wid->getFieldShortType()));
+        });
+    }
+
+
+
+    _chart = new ChartWidget;
+    _chart->setMinimumSize(640, 400);
+
+    auto layout = new QHBoxLayout(this);
+    layout->addWidget(barplot_wid);
+
+    auto vlayout = new QVBoxLayout(this);
+    auto hlayout = new QHBoxLayout(this);
+    hlayout->addWidget(jstate_wid);
+
+    vlayout->addLayout(hlayout);
+    vlayout->addWidget(_chart);
+
+    layout->addLayout(vlayout);
+    setLayout(layout);
+
+    connect(jstate_wid, &JointStateWidget::plotAdded,
+            [this](QString plot)
+            {
+                _chart->addSeries(jstate_wid->getJointName() + "/" + plot);
+            });
+
+
+//     _timer = new QTimer(this);
+//     _timer->setInterval(40);
+//     connect(_timer, &QTimer::timeout,
+//             this, &JointMonitorWidget::on_timer_event);
+//     _timer->start();
+
+    _widget_started = true;
+
+
+}
+
+void JointMonitorWidget::on_timer_event()
+{
+    ros::spinOnce();
+}
+
+void JointMonitorWidget::on_jstate_recv(const sensor_msgs::JointStateConstPtr& msg)
+{
+    if(!_valid_msg_recv)
+    {
+        _jnames = msg->name;
+        _valid_msg_recv = true;
+        return;
+    }
+
+    if(!_widget_started)
+    {
+        return;
+    }
+
+    static auto t0 = msg->header.stamp;
+    auto now = msg->header.stamp;
+
+
+
+    for(int i = 0; i < msg->name.size(); i++)
+    {
+
+        _chart->addPoint(QString::fromStdString(msg->name[i]) + "/joint_pos",
+                         (now - t0).toSec(),
+                         msg->position[i]);
+
+        _chart->addPoint(QString::fromStdString(msg->name[i]) + "/joint_vel",
+                         (now - t0).toSec(),
+                         msg->velocity[i]);
+
+        _chart->addPoint(QString::fromStdString(msg->name[i]) + "/joint_effort",
+                         (now - t0).toSec(),
+                         msg->effort[i]);
+
+
+        if(msg->name[i] == jstate_wid->getJointName().toStdString())
+        {
+            jstate_wid->jointEff->setValue(msg->effort[i]);
+            jstate_wid->jointPos->setValue(msg->position[i]);
+            jstate_wid->jointVel->setValue(msg->velocity[i]);
+          
+
+            std::string fault_str = "Ok";
+
+            jstate_wid->setStatus(fault_str);
+
+        }
+
+        //if(msg->fault[i] == 0)
+        //{
+            auto wid = barplot_wid->wid_map.at(msg->name[i]);
+            wid->setSafe();
+
+        //else
+        //{
+        //   auto wid = barplot_wid->wid_map.at(msg->name[i]);
+        //     wid->setDanger();
+        //}
+
+
+        if(barplot_wid->getFieldType() == "Joint Effort")
+        {
+            auto wid = barplot_wid->wid_map.at(msg->name[i]);
+            wid->setValue(std::fabs(msg->effort[i]), msg->effort[i]);
+            double taumax = _urdf->getJoint(msg->name[i])->limits->effort;
+            wid->setRange(0, taumax);
+
+        }
+       
+        else if(barplot_wid->getFieldType() == "Joint Position")
+        {
+            auto wid = barplot_wid->wid_map.at(msg->name[i]);
+            wid->setValue(msg->position[i]);
+            double qmin = _urdf->getJoint(msg->name[i])->limits->lower;
+            double qmax = _urdf->getJoint(msg->name[i])->limits->upper;
+            wid->setRange(qmin, qmax);
+        }
+        
+        else if(barplot_wid->getFieldType() == "Joint Velocity")
+        {
+            auto wid = barplot_wid->wid_map.at(msg->name[i]);
+            wid->setValue(msg->velocity[i]);
+            double qdmax = _urdf->getJoint(msg->name[i])->limits->velocity;
+            wid->setRange(0, qdmax);
+        }
+        
+    }
+
+}

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -147,7 +147,7 @@ JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh,
         wid->setActive();
     };
 
-    on_joint_clicked(_jnames[0]);
+    on_joint_clicked(jointsOrdered[0]);
 
     for(auto p: barplot_wid->wid_map)
     {

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -170,28 +170,19 @@ JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh,
             
         if (type == ROSEE::JointActuatedType::ACTUATED) {
             
-            //setStylesheet cant be used because is used already in joint_bar_widget.cpp
-            //to make bold or not when double clicked, and it would ovewrite the color
-            p.second->findChild<QLabel *>("JointLabel")->setText(
-                p.second->findChild<QLabel *>("JointLabel")->text()
-                    .prepend("<p style='background-color: rgba(0,255,0,0.3)'>")
-                    .append("</p>"));
+            p.second->findChild<QLabel *>("JointLabel")->setStyleSheet(
+                "background-color: rgba(0,255,0,0.5)");
 
         } else if (type == ROSEE::JointActuatedType::MIMIC) {
 
-            p.second->findChild<QLabel *>("JointLabel")->setText(
-                p.second->findChild<QLabel *>("JointLabel")->text()
-                    .prepend("<p style='background-color: rgba(255,255,0,0.3)'>")
-                    .append("</p>"));
+            p.second->findChild<QLabel *>("JointLabel")->setStyleSheet(
+                "background-color: rgba(255,255,0,0.5)");
             
         } else {
             
-            p.second->findChild<QLabel *>("JointLabel")->setText(
-                p.second->findChild<QLabel *>("JointLabel")->text()
-                    .prepend("<p style='background-color: rgba(255,0,0,0.3)'>")
-                    .append("</p>"));
+            p.second->findChild<QLabel *>("JointLabel")->setStyleSheet(
+                "background-color: rgba(255,0,0,0.5)");
         }
-
     }
 
     _chart = new ChartWidget;
@@ -199,12 +190,9 @@ JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh,
 
     auto layout = new QHBoxLayout(this);
     layout->addWidget(barplot_wid);
-
+    
     auto vlayout = new QVBoxLayout(this);
-    auto hlayout = new QHBoxLayout(this);
-    hlayout->addWidget(jstate_wid);
-
-    vlayout->addLayout(hlayout);
+    vlayout->addWidget(jstate_wid);
     vlayout->addWidget(_chart);
 
     layout->addLayout(vlayout);

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -163,9 +163,36 @@ JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh,
                               "/" +
                               QString::fromStdString(barplot_wid->getFieldShortType()));
         });
+        
+        //color the joint names accordingly to actuated type
+        auto mapEl = robotDescriptionHandler->getActuatedJointsMap().find(p.first);
+        if (mapEl == robotDescriptionHandler->getActuatedJointsMap().end()){
+            ROS_WARN_STREAM (__func__ << " '" << p.first << "' not found in the table of joint states" );
+        
+        } else {
+            
+            if (mapEl->second == ROSEE::JointActuatedType::ACTUATED) {
+                //setStylesheet cant be used because is used already in joint_bar_widget.cpp
+                //to make bold or not when double clicked, and it would ovewrite the color
+                p.second->findChild<QLabel *>("JointLabel")->setText(
+                    p.second->findChild<QLabel *>("JointLabel")->text()
+                        .prepend("<p style='background-color: rgba(0,255,0,0.3)'>")
+                        .append("</p>"));
+                
+            } else if (mapEl->second == ROSEE::JointActuatedType::MIMIC) {
+                p.second->findChild<QLabel *>("JointLabel")->setText(
+                    p.second->findChild<QLabel *>("JointLabel")->text()
+                        .prepend("<p style='background-color: rgba(255,255,0,0.3)'>")
+                        .append("</p>"));
+                
+            } else {
+                p.second->findChild<QLabel *>("JointLabel")->setText(
+                    p.second->findChild<QLabel *>("JointLabel")->text()
+                        .prepend("<p style='background-color: rgba(255,0,0,0.3)'>")
+                        .append("</p>"));
+            }
+        }
     }
-
-
 
     _chart = new ChartWidget;
     _chart->setMinimumSize(640, 400);

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -90,7 +90,9 @@ union centAC_fault_t{
     BIT_FAULT bit;
 };
 
-JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh, QWidget *parent) :
+JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh, 
+                                       std::shared_ptr<RobotDescriptionHandler> robotDescriptionHandler, 
+                                       QWidget *parent) :
     QWidget(parent),
     _valid_msg_recv(false),
     _widget_started(false)
@@ -101,16 +103,9 @@ JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh, QWidget *parent) :
     _jstate_sub = nh->subscribe(jsTopic, 10, &JointMonitorWidget::on_jstate_recv, this);
     ROS_INFO_STREAM ( "[2nd Tab] Getting joint pos from '" << jsTopic << "'" );
 
+    this->_robotDescriptionHandler = robotDescriptionHandler;
 
-    std::string urdf_str;
-    nh->getParam("robot_description", urdf_str);
-
-    if(urdf_str.empty())
-    {
-        throw std::runtime_error("Unable to read robot_description from parameter server");
-    }
-
-    _urdf = urdf::parseURDF(urdf_str);
+    _urdf = _robotDescriptionHandler->getUrdfModel();
 
     while(!_valid_msg_recv)
     {

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -164,34 +164,34 @@ JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh,
                               QString::fromStdString(barplot_wid->getFieldShortType()));
         });
         
-        //color the joint names accordingly to actuated type
-        auto mapEl = robotDescriptionHandler->getActuatedJointsMap().find(p.first);
-        if (mapEl == robotDescriptionHandler->getActuatedJointsMap().end()){
-            ROS_WARN_STREAM (__func__ << " '" << p.first << "' not found in the table of joint states" );
         
+        //color the joint names accordingly to actuated type
+        ROSEE::JointActuatedType type = robotDescriptionHandler->getActuatedJointsMap().at(p.first);
+            
+        if (type == ROSEE::JointActuatedType::ACTUATED) {
+            
+            //setStylesheet cant be used because is used already in joint_bar_widget.cpp
+            //to make bold or not when double clicked, and it would ovewrite the color
+            p.second->findChild<QLabel *>("JointLabel")->setText(
+                p.second->findChild<QLabel *>("JointLabel")->text()
+                    .prepend("<p style='background-color: rgba(0,255,0,0.3)'>")
+                    .append("</p>"));
+
+        } else if (type == ROSEE::JointActuatedType::MIMIC) {
+
+            p.second->findChild<QLabel *>("JointLabel")->setText(
+                p.second->findChild<QLabel *>("JointLabel")->text()
+                    .prepend("<p style='background-color: rgba(255,255,0,0.3)'>")
+                    .append("</p>"));
+            
         } else {
             
-            if (mapEl->second == ROSEE::JointActuatedType::ACTUATED) {
-                //setStylesheet cant be used because is used already in joint_bar_widget.cpp
-                //to make bold or not when double clicked, and it would ovewrite the color
-                p.second->findChild<QLabel *>("JointLabel")->setText(
-                    p.second->findChild<QLabel *>("JointLabel")->text()
-                        .prepend("<p style='background-color: rgba(0,255,0,0.3)'>")
-                        .append("</p>"));
-                
-            } else if (mapEl->second == ROSEE::JointActuatedType::MIMIC) {
-                p.second->findChild<QLabel *>("JointLabel")->setText(
-                    p.second->findChild<QLabel *>("JointLabel")->text()
-                        .prepend("<p style='background-color: rgba(255,255,0,0.3)'>")
-                        .append("</p>"));
-                
-            } else {
-                p.second->findChild<QLabel *>("JointLabel")->setText(
-                    p.second->findChild<QLabel *>("JointLabel")->text()
-                        .prepend("<p style='background-color: rgba(255,0,0,0.3)'>")
-                        .append("</p>"));
-            }
+            p.second->findChild<QLabel *>("JointLabel")->setText(
+                p.second->findChild<QLabel *>("JointLabel")->text()
+                    .prepend("<p style='background-color: rgba(255,0,0,0.3)'>")
+                    .append("</p>"));
         }
+
     }
 
     _chart = new ChartWidget;

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -128,11 +128,14 @@ JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh,
         }
     }
 
+    //we use a vector which contains all joint names, but ordered by type
+    //first the active, then the mimic, then the passive.
+    std::vector<std::string> jointsOrdered = robotDescriptionHandler->getAllJoints();
 
     jstate_wid = new JointStateWidget(this);
-    jstate_wid->setJointName(QString::fromStdString(_jnames[0]), 0);
+    jstate_wid->setJointName(QString::fromStdString(jointsOrdered[0]), 0);
 
-    barplot_wid = new BarPlotWidget(_jnames, this);
+    barplot_wid = new BarPlotWidget(jointsOrdered, this);
 
     auto on_joint_clicked = [this](std::string jname)
     {
@@ -162,27 +165,34 @@ JointMonitorWidget::JointMonitorWidget(ros::NodeHandle* nh,
         
         
         //color the joint names accordingly to actuated type
-        ROSEE::JointActuatedType type = robotDescriptionHandler->getActuatedJointsMap().at(p.first);
+        ROSEE::JointActuatedType type = 
+            robotDescriptionHandler->getActuatedTypeJointsMap().at(p.first);
             
-        if (type == ROSEE::JointActuatedType::ACTUATED) {
-            
-            p.second->findChild<QLabel *>("JointLabel")->setStyleSheet(
-                "background-color: rgba(0,255,0,0.5)");
+        QString temp = p.second->findChild<QLabel *>("JointLabel")->text();
 
+        if (type == ROSEE::JointActuatedType::ACTIVE) {
+            
+            temp.append(" (active)" );
+            p.second->findChild<QLabel *>("JointLabel")->setText(temp);
+            
         } else if (type == ROSEE::JointActuatedType::MIMIC) {
 
-            p.second->findChild<QLabel *>("JointLabel")->setStyleSheet(
-                "background-color: rgba(255,255,0,0.5)");
+            temp.append(" (mimic)" );
+            p.second->findChild<QLabel *>("JointLabel")->setText(temp);
+            
+        } else if (type == ROSEE::JointActuatedType::PASSIVE) {
+            
+            temp.append(" (passive)" );
+            p.second->findChild<QLabel *>("JointLabel")->setText(temp);
             
         } else {
-            
-            p.second->findChild<QLabel *>("JointLabel")->setStyleSheet(
-                "background-color: rgba(255,0,0,0.5)");
+            temp.append(" (type unknown)" );
+            p.second->findChild<QLabel *>("JointLabel")->setText(temp);
         }
     }
 
     _chart = new ChartWidget;
-    _chart->setMinimumSize(640, 400);
+    _chart->setMinimumSize(900, 400);
 
     auto layout = new QHBoxLayout(this);
     layout->addWidget(barplot_wid);

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -230,6 +230,8 @@ void JointMonitorWidget::on_jstate_recv(const sensor_msgs::JointStateConstPtr& m
     {
         return;
     }
+    
+
 
     static auto t0 = msg->header.stamp;
     auto now = msg->header.stamp;
@@ -238,6 +240,11 @@ void JointMonitorWidget::on_jstate_recv(const sensor_msgs::JointStateConstPtr& m
 
     for(int i = 0; i < msg->name.size(); i++)
     {
+        
+        if (_urdf->getJoint(msg->name[i])->type == urdf::Joint::FIXED) {
+            ROS_WARN_STREAM ("JointMonitorWidget::on_jstate_recv: received state for the fixed joint " << msg->name[i] << ", skipping it");
+            continue;
+        }
 
         _chart->addPoint(QString::fromStdString(msg->name[i]) + "/joint_pos",
                          (now - t0).toSec(),

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -1,8 +1,4 @@
 #include "joint_monitor_widget.h"
-#include "bar_plot_widget.h"
-#include <QHBoxLayout>
-
-#include <urdf_parser/urdf_parser.h>
 
 struct BIT_FAULT {
 

--- a/src/joint_state_gui/joint_monitor_widget.h
+++ b/src/joint_state_gui/joint_monitor_widget.h
@@ -10,6 +10,9 @@
 #include <yaml-cpp/yaml.h>
 #include <urdf_parser/urdf_parser.h>
 
+//TODO solve this
+#include "../../include/rosee_gui/RobotDescriptionHandler.h"
+
 #include "bar_plot_widget.h"
 #include "joint_state_widget.h"
 #include "../chart/chart.h"
@@ -20,7 +23,7 @@ class JointMonitorWidget : public QWidget
 
 public:
 
-    explicit JointMonitorWidget(ros::NodeHandle* nh, QWidget *parent = nullptr);
+    explicit JointMonitorWidget(ros::NodeHandle* nh, std::shared_ptr<RobotDescriptionHandler>, QWidget *parent = nullptr);
 
 
     BarPlotWidget * barplot_wid;
@@ -35,6 +38,8 @@ private:
     bool _widget_started;
     std::vector<std::string> _jnames;
     urdf::ModelInterfaceSharedPtr _urdf;
+    
+    std::shared_ptr<RobotDescriptionHandler> _robotDescriptionHandler;
 
     void on_timer_event();
     void on_jstate_recv(const sensor_msgs::JointStateConstPtr& msg);

--- a/src/joint_state_gui/joint_monitor_widget.h
+++ b/src/joint_state_gui/joint_monitor_widget.h
@@ -1,0 +1,46 @@
+#ifndef JOINT_MONITOR_WIDGET_H
+#define JOINT_MONITOR_WIDGET_H
+
+#include <QWidget>
+#include <QTimer>
+
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <sensor_msgs/JointState.h>
+#include <yaml-cpp/yaml.h>
+#include <urdf_parser/urdf_parser.h>
+
+#include "bar_plot_widget.h"
+#include "joint_state_widget.h"
+#include "../chart/chart.h"
+
+
+class JointMonitorWidget : public QWidget
+{
+
+public:
+
+    explicit JointMonitorWidget(ros::NodeHandle* nh, QWidget *parent = nullptr);
+
+
+    BarPlotWidget * barplot_wid;
+    JointStateWidget * jstate_wid;
+
+private:
+
+    ChartWidget * _chart;
+    QTimer * _timer;
+    ros::Subscriber _jstate_sub;
+    bool _valid_msg_recv;
+    bool _widget_started;
+    std::vector<std::string> _jnames;
+    urdf::ModelInterfaceSharedPtr _urdf;
+
+    void on_timer_event();
+    void on_jstate_recv(const sensor_msgs::JointStateConstPtr& msg);
+
+    std::map<std::string, int> _jidmap;
+
+};
+
+#endif // JOINT_MONITOR_WIDGET_H

--- a/src/joint_state_gui/joint_monitor_widget.h
+++ b/src/joint_state_gui/joint_monitor_widget.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include <QTimer>
+#include <QHBoxLayout>
 
 #include <ros/ros.h>
 #include <ros/console.h>

--- a/src/joint_state_gui/joint_state_widget.cpp
+++ b/src/joint_state_gui/joint_state_widget.cpp
@@ -66,7 +66,7 @@ JointStateWidget::JointStateWidget(QWidget * parent):
 
     auto plot_joint_eff = findChild<QPushButton *>("plotJointEff");
     connect(plot_joint_eff, &QPushButton::released,
-            [this](){ emit plotAdded("joint_effort");});
+            [this](){ emit plotAdded("joint_eff");});
 
 }
 

--- a/src/joint_state_gui/joint_state_widget.cpp
+++ b/src/joint_state_gui/joint_state_widget.cpp
@@ -1,0 +1,82 @@
+#include "joint_state_widget.h"
+
+#include <QUiLoader>
+#include <QFile>
+#include <QVBoxLayout>
+#include <QComboBox>
+#include <QPushButton>
+
+void joint_state_widget_qrc_init()
+{
+    Q_INIT_RESOURCE(ui_resources);
+}
+
+namespace  {
+
+
+QWidget * LoadUiFile(QWidget * parent)
+{
+    joint_state_widget_qrc_init();
+
+    QUiLoader loader;
+
+    QFile file(":/joint_state_widget.ui");
+    file.open(QFile::ReadOnly);
+
+    QWidget *formWidget = loader.load(&file, parent);
+    file.close();
+
+    return formWidget;
+
+
+}
+
+}
+
+
+JointStateWidget::JointStateWidget(QWidget * parent):
+    QWidget(parent)
+{
+    /* Create GUI layout */
+    auto * ui = ::LoadUiFile(this);
+    auto * layout = new QVBoxLayout;
+    layout->addWidget(ui);
+    setLayout(layout);
+    setMinimumWidth(400);
+
+    jointEff = findChild<QDoubleSpinBox *>("jointEff");
+    jointVel = findChild<QDoubleSpinBox *>("jointVel");
+    jointPos = findChild<QDoubleSpinBox *>("jointPos");
+
+    group = findChild<QGroupBox *>("JointStateGroup");
+
+    _fault = findChild<QLabel *>("faulttext");
+
+    jointPos        ->setRange(-1e9, 1e9);
+    jointVel        ->setRange(-1e9, 1e9);
+    jointEff     ->setRange(-1e9, 1e9);
+
+    auto plot_link_pos = findChild<QPushButton *>("plotJointPos");
+    connect(plot_link_pos, &QPushButton::released,
+            [this](){ emit plotAdded("joint_pos");});
+
+    auto plot_ref_pos = findChild<QPushButton *>("plotJointVel");
+    connect(plot_ref_pos, &QPushButton::released,
+            [this](){ emit plotAdded("joint_vel");});
+
+    auto plot_moto_pos = findChild<QPushButton *>("plotJointEff");
+    connect(plot_moto_pos, &QPushButton::released,
+            [this](){ emit plotAdded("joint_effort");});
+
+}
+
+void JointStateWidget::setJointName(QString jname, int jid)
+{
+    group->setTitle(QString("%1  (ID: %2)").arg(jname).arg(jid));
+    _jname = jname;
+}
+
+void JointStateWidget::setStatus(std::string status)
+{
+    _fault->setText(QString::fromStdString(status));
+}

--- a/src/joint_state_gui/joint_state_widget.cpp
+++ b/src/joint_state_gui/joint_state_widget.cpp
@@ -56,16 +56,16 @@ JointStateWidget::JointStateWidget(QWidget * parent):
     jointVel        ->setRange(-1e9, 1e9);
     jointEff     ->setRange(-1e9, 1e9);
 
-    auto plot_link_pos = findChild<QPushButton *>("plotJointPos");
-    connect(plot_link_pos, &QPushButton::released,
+    auto plot_joint_pos = findChild<QPushButton *>("plotJointPos");
+    connect(plot_joint_pos, &QPushButton::released,
             [this](){ emit plotAdded("joint_pos");});
 
-    auto plot_ref_pos = findChild<QPushButton *>("plotJointVel");
-    connect(plot_ref_pos, &QPushButton::released,
+    auto plot_joint_vel = findChild<QPushButton *>("plotJointVel");
+    connect(plot_joint_vel, &QPushButton::released,
             [this](){ emit plotAdded("joint_vel");});
 
-    auto plot_moto_pos = findChild<QPushButton *>("plotJointEff");
-    connect(plot_moto_pos, &QPushButton::released,
+    auto plot_joint_eff = findChild<QPushButton *>("plotJointEff");
+    connect(plot_joint_eff, &QPushButton::released,
             [this](){ emit plotAdded("joint_effort");});
 
 }

--- a/src/joint_state_gui/joint_state_widget.h
+++ b/src/joint_state_gui/joint_state_widget.h
@@ -1,0 +1,38 @@
+#ifndef JOINT_STATE_WIDGET_H
+#define JOINT_STATE_WIDGET_H
+
+#include <QWidget>
+#include <QGroupBox>
+#include <QDoubleSpinBox>
+#include <QLabel>
+
+class JointStateWidget : public QWidget
+{
+
+    Q_OBJECT
+
+public:
+
+    explicit JointStateWidget(QWidget * parent = nullptr);
+
+    void setJointName(QString jname, int jid);
+
+    QDoubleSpinBox * jointPos, * jointVel, * jointEff;
+    
+    QString getJointName() const { return _jname; }
+    void setStatus(std::string status);
+
+signals:
+
+    void plotAdded(QString field);
+
+private:
+
+    QGroupBox * group;
+    QString _jname;
+    QLabel * _fault;
+
+
+};
+
+#endif // JOINT_STATE_WIDGET_H

--- a/src/joint_state_gui/joint_state_widget.ui
+++ b/src/joint_state_gui/joint_state_widget.ui
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>451</width>
+    <height>858</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="JointStateGroup">
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Joint name (ID: null)</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Joint Position</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="jointPos">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::NoButtons</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="plotJointPos">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Plot</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Joint Velocity</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="jointVel">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::NoButtons</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="plotJointVel">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Plot</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Joint Effort</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="jointEff">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::NoButtons</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="plotJointEff">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Plot</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_20">
+        <item>
+         <widget class="QLabel" name="label_20">
+          <property name="text">
+           <string>Fault</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="faulttext">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Ok</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="plotFault">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>60</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Plot</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/joint_state_gui/ui_resources.qrc
+++ b/src/joint_state_gui/ui_resources.qrc
@@ -1,0 +1,7 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource>
+    <file>bar_plot_widget.ui</file>
+    <file>joint_bar_widget.ui</file>
+    <file>joint_state_widget.ui</file>
+</qresource>
+</RCC>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include <QSlider>
 #include <QPushButton>
 
-#include <rosee_gui/Window.h>
+#include <rosee_gui/MainWindow.h>
 #include <rosee_gui/TimerHandler.h>
 #include <ros/ros.h>
 
@@ -15,10 +15,11 @@ int main(int argc, char **argv)
     ros::NodeHandle nh;
     
     TimerHandler tHandler(100);
+    
+    
+    MainWindow mainwindow(&nh);
 
-    Window window(&nh);
-
-    window.show();
+    mainwindow.show();
     
     int appReturn = app.exec();
     //app.exec is blocking

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,13 +9,13 @@
 
 int main(int argc, char **argv)
 {
+
     QApplication app (argc, argv);
 
     ros::init (argc, argv, "rosee_GUI");
     ros::NodeHandle nh;
     
     TimerHandler tHandler(100);
-    
     
     MainWindow mainwindow(&nh);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
     ros::init (argc, argv, "rosee_GUI");
     ros::NodeHandle nh;
     
-    TimerHandler tHandler(10);
+    TimerHandler tHandler(100);
 
     Window window(&nh);
 


### PR DESCRIPTION
Now we support 2 different qt version : above 5.9 and below.
If above 5.9, second tab (from https://github.com/ADVRHumanoids/robot_monitoring) is available, otherwise it will not be loaded

There are also some other improvements on the first tab that includes:
- tables with active, mimic and passive joint state
- Reset button
- visual enhancements

related issue : #14, https://github.com/ADVRHumanoids/ROSEndEffectorDocs/issues/24
  